### PR TITLE
Initialize the host kb from hosts_new().

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -1131,16 +1131,16 @@ attack_network (struct scan_globals *globals, kb_t *network_kb)
       struct attack_start_args args;
       char *host_str;
 
-      rc = kb_new (&host_kb, prefs_get ("db_address"));
-      if (rc)
-        {
-          report_kb_failure (global_socket, rc);
-          goto scan_stop;
-        }
       host_str = gvm_host_value_str (host);
-      if (hosts_new (globals, host_str, host_kb) < 0)
+      rc = hosts_new (globals, host_str, &host_kb);
+      if (rc == -1)
         {
           g_free (host_str);
+          goto scan_stop;
+        }
+      if (rc == -2)
+        {
+          report_kb_failure (global_socket, rc);
           goto scan_stop;
         }
 

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -32,7 +32,7 @@ int
 hosts_init (int, int);
 
 int
-hosts_new (struct scan_globals *, char *, kb_t);
+hosts_new (struct scan_globals *, char *, kb_t *);
 
 int
 hosts_set_pid (char *, pid_t);

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -85,6 +85,7 @@
 #define PROCTITLE_RELOADING "openvassd: Reloading"
 #define PROCTITLE_SERVING "openvassd: Serving %s"
 
+#define KB_RETRY_DELAY 60
 /**
  * Globals that should not be touched (used in utils module).
  */
@@ -615,13 +616,23 @@ stop_all_scans (void)
 void
 check_kb_status ()
 {
-  int waitredis = 5, waitkb = 5, ret = 0;
-
+  int waitredis = 5, waitkb = 5, ret = 0, log_flag = 1;
   kb_t kb_access_aux;
 
   while (waitredis != 0)
     {
       ret = kb_new (&kb_access_aux, prefs_get ("db_address"));
+      if (ret == -2)
+        {
+          if (log_flag)
+            {
+              g_warning ("No redis DB available, It will retry every %ds...",
+                         KB_RETRY_DELAY);
+              log_flag = 0;
+            }
+          sleep (KB_RETRY_DELAY);
+          continue;
+        }
       if (ret)
         {
           g_message ("Redis connection lost. Trying to reconnect.");
@@ -634,6 +645,7 @@ check_kb_status ()
           kb_delete (kb_access_aux);
           break;
         }
+      log_flag = 1;
     }
 
   if (waitredis == 0)


### PR DESCRIPTION
If there is no more availabe redis kb, it will wait until a host finishes
and release a db for the next one.
This avoid to hanging in the kb initialization and keeps working the results forwarding.