### PR TITLE
Separate each scan plugin process into its own process group.

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -300,7 +300,7 @@ launch_plugin (struct arglist *globals, struct scheduler_plugin *plugin,
       if (kb_item_get_int (kb, "Host/dead") > 0)
         {
           log_write ("The remote host %s (%s) is dead", hostinfos->fqdn, hostname);
-          pluginlaunch_stop (1);
+          pluginlaunch_stop ();
           plugin->running_state = PLUGIN_STATUS_DONE;
           g_free (name);
           return ERR_HOST_DEAD;
@@ -484,7 +484,7 @@ attack_host (struct arglist *globals, struct host_info *hostinfos,
       parent = getppid ();
       if (parent <= 1 || process_alive (parent) == 0)
         {
-          pluginlaunch_stop (1);
+          pluginlaunch_stop ();
           return;
         }
 
@@ -546,7 +546,7 @@ attack_host (struct arglist *globals, struct host_info *hostinfos,
               if (comm_send_status
                    (global_socket, hostname, cur_plug, num_plugs) < 0)
                 {
-                  pluginlaunch_stop (1);
+                  pluginlaunch_stop ();
                   goto host_died;
                 }
             }
@@ -563,7 +563,7 @@ attack_host (struct arglist *globals, struct host_info *hostinfos,
     comm_send_status (global_socket, hostname, num_plugs, num_plugs);
 
 host_died:
-  pluginlaunch_stop (1);
+  pluginlaunch_stop ();
   plugins_scheduler_free (sched);
 
   if (net_kb == NULL || kb != *net_kb)
@@ -902,7 +902,7 @@ check_kb_access (int soc)
 static void
 handle_scan_stop_signal ()
 {
-  pluginlaunch_stop (0);
+  pluginlaunch_stop ();
   global_scan_stop = 1;
 }
 

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -175,6 +175,9 @@ nasl_thread (struct nasl_thread_args *nargs)
   kb_t kb;
   GError *error = NULL;
 
+  /* Make plugin process a group leader, to make it easier to cleanup forked
+   * processes & their children. */
+  setpgid (0, 0);
   nvticache_reset ();
   if (prefs_get_bool ("be_nice"))
     {

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -376,27 +376,15 @@ pluginlaunch_enable_parrallel_checks (void)
 
 
 void
-pluginlaunch_stop (int soft_stop)
+pluginlaunch_stop ()
 {
   int i;
-
-  if (soft_stop)
-    {
-      read_running_processes ();
-
-      for (i = 0; i < MAX_PROCESSES; i++)
-        {
-          if (processes[i].pid > 0)
-            kill (processes[i].pid, SIGTERM);
-        }
-      usleep (20000);
-    }
 
   for (i = 0; i < MAX_PROCESSES; i++)
     {
       if (processes[i].pid > 0)
         {
-          kill (processes[i].pid, SIGKILL);
+          terminate_process (processes[i].pid * -1);
           num_running_processes--;
           processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
           close (processes[i].internal_soc);

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -183,7 +183,6 @@ update_running_processes (void)
                                  msg, INTERNAL_COMM_MSG_TYPE_DATA);
                   g_free (msg);
 
-                  terminate_process (processes[i].pid);
                   processes[i].alive = 0;
                 }
               else
@@ -214,6 +213,7 @@ update_running_processes (void)
                   while (e < 0 && errno == EINTR);
 
                 }
+              terminate_process (processes[i].pid * -1);
               num_running_processes--;
               processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
               close (processes[i].internal_soc);

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -36,7 +36,10 @@
 void pluginlaunch_init (const char *);
 void pluginlaunch_wait (void);
 void pluginlaunch_wait_for_free_process (void);
-void pluginlaunch_stop (int);
+
+void
+pluginlaunch_stop ();
+
 int plugin_launch (struct arglist *, struct scheduler_plugin *,
                    struct host_info *, kb_t, char *);
 

--- a/src/processes.c
+++ b/src/processes.c
@@ -44,7 +44,7 @@ terminate_process (pid_t pid)
 {
   int ret;
 
-  if (pid <= 0)
+  if (pid == 0)
     return 0;
 
   ret = kill (pid, SIGTERM);


### PR DESCRIPTION
This makes cleaning-up children easier, and fixes issue of forgotten children of children.

Backport of parts from https://github.com/greenbone/openvas-scanner/pull/324