### PR TITLE
Slow rsync commands to prevent IP blocking

### DIFF
--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -502,6 +502,8 @@ do_sync_community_feed () {
 }
 
 sync_nvts(){
+  # Sleep for ten seconds to prevent IP blocking.
+  sleep 10
   if [ $ENABLED -ne 1 ]
   then
     log_write "NVT synchronization is disabled, exiting."


### PR DESCRIPTION
Two rsync commands run in fairly quick succession to check if the feed is current and sync down new changes if it is not. I've found these run too quickly most of the time and the second rsync is blocked by the server which causes the update to fail. Adding a delay before the second rsync resolves the issue.

This is related to the open pull request in the [greenbone/gvmd](https://github.com/greenbone/gvmd) repository:
[Fix rsync errors due to IP blocking](https://github.com/greenbone/gvmd/pull/326)