### PR TITLE
Initialize the host kb from hosts_new()

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -1111,16 +1111,16 @@ attack_network (struct scan_globals *globals, kb_t *network_kb)
       struct attack_start_args args;
       char *host_str;
 
-      rc = kb_new (&host_kb, prefs_get ("db_address"));
-      if (rc)
-        {
-          report_kb_failure (global_socket, rc);
-          goto scan_stop;
-        }
       host_str = gvm_host_value_str (host);
-      if (hosts_new (globals, host_str, host_kb) < 0)
+      rc = hosts_new (globals, host_str, &host_kb);
+      if (rc == -1)
         {
           g_free (host_str);
+          goto scan_stop;
+        }
+      if (rc == -2)
+        {
+          report_kb_failure (global_socket, rc);
           goto scan_stop;
         }
 

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -32,7 +32,7 @@ int
 hosts_init (int, int);
 
 int
-hosts_new (struct scan_globals *, char *, kb_t);
+hosts_new (struct scan_globals *, char *, kb_t *);
 
 int
 hosts_set_pid (char *, pid_t);


### PR DESCRIPTION
If there is no more availabe redis kb, it will wait until a host finishes
and release a db for the next one.
This avoid to hanging in the kb initialization and keeps working the results forwarding.