### PR TITLE
Renaming from openvas-scanner to openvas.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,11 @@
-SUMMARY OF RELEASE CHANGES FOR OPENVAS-SCANNER
-==============================================
+SUMMARY OF RELEASE CHANGES FOR OPENVAS
+======================================
 
 For detailed code changes, please visit
- https://github.com/greenbone/openvas-scanner/commits/master
+ https://github.com/greenbone/openvas/commits/master
 or get the entire source code repository and view log history:
-$ git clone https://github.com/greenbone/openvas-scanner.git
-$ cd openvas-scanner && git log
+$ git clone https://github.com/greenbone/openvas.git
+$ cd openvas && git log
 
 openvas-scanner 7.0+beta1 (unreleased)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ cmake_minimum_required (VERSION 3.0)
 
 message ("-- Configuring the Scanner...")
 
-project (openvas-scanner
+project (openvas
   VERSION 7.0.0
   LANGUAGES C)
 
@@ -86,7 +86,7 @@ set (PROJECT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${
 
 set (CPACK_CMAKE_GENERATOR "Unix Makefiles")
 set (CPACK_GENERATOR "TGZ")
-set (CPACK_INSTALL_CMAKE_PROJECTS ".;openvas-scanner;ALL;/")
+set (CPACK_INSTALL_CMAKE_PROJECTS ".;openvas;ALL;/")
 set (CPACK_MODULE_PATH "")
 set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 set (CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,12 @@
-INSTALLATION INSTRUCTIONS FOR OPENVAS-SCANNER
-=============================================
+INSTALLATION INSTRUCTIONS FOR OPENVAS
+=====================================
 
 Please note: The reference system used by most of the developers is Debian
 GNU/Linux 'Stretch' 9. The build might fail on any other system. Also, it is
 necessary to install dependent development packages.
 
-Prerequisites for openvas-scanner
----------------------------------
+Prerequisites for openvas
+-------------------------
 
 Prerequisites:
 * a C compiler (e.g. gcc)
@@ -45,8 +45,8 @@ Install prerequisites on Debian GNU/Linux 'Stretch' 9:
     libpcap-dev libgpgme-dev bison libksba-dev libsnmp-dev libgcrypt20-dev
 
 
-Compiling openvas-scanner
--------------------------
+Compiling openvas
+-----------------
 
 If you have installed required libraries to a non-standard location, remember to
 set the `PKG_CONFIG_PATH` environment variable to the location of you pkg-config
@@ -98,15 +98,15 @@ all compiler warnings, it may lead the build process to abort on your system.
 
 Should you notice error messages causing your build process to abort, do not
 hesitate to contact the developers by creating a 
-[new issue report](https://github.com/greenbone/openvas-scanner/issues/new).
+[new issue report](https://github.com/greenbone/openvas/issues/new).
 Don't forget to include the name and version of your compiler and distribution in your
 message.
 
 
-Setting up openvas-scanner
---------------------------
+Setting up openvas
+------------------
 
-Setting up an openvas-scanner requires the following steps:
+Setting up an openvas requires the following steps:
 
 1. (optional) You may decide to change the default scanner preferences
    by setting them in the file `$prefix/etc/openvas.conf`. If that file does
@@ -117,9 +117,9 @@ Setting up an openvas-scanner requires the following steps:
    scan targets and interfaces.
 
 2. In order to run vulnerability scans, you will need a collection of Network
-   Vulnerability Tests (NVTs) that can be run by openvas-scanner. Initially,
+   Vulnerability Tests (NVTs) that can be run by openvas. Initially,
    your NVT collection will be empty. It is recommended that you synchronize
-   with an NVT feed service before starting openvas-scanner for the first time.
+   with an NVT feed service before starting openvas for the first time.
 
    Simply execute the following command to retrieve the initial NVT collection:
 
@@ -145,15 +145,15 @@ Setting up an openvas-scanner requires the following steps:
    Multiple examples for various Redis versions are installed which you may use
    directly for a quick start:
 
-       redis-server <install-prefix>/share/doc/openvas-scanner/redis_config_examples/redis_3_2.conf
+       redis-server <install-prefix>/share/doc/openvas/redis_config_examples/redis_3_2.conf
 
    or
 
-       redis-server <install-prefix>/share/doc/openvas-scanner/redis_config_examples/redis_4_0.conf
+       redis-server <install-prefix>/share/doc/openvas/redis_config_examples/redis_4_0.conf
 
    or copy the example to another location, edit and use the copy instead.
 
-4. You can launch openvas-scanner using the following command:
+4. You can launch openvas using the following command:
 
        openvas
 
@@ -181,10 +181,9 @@ If you encounter problems, by default the scanner writes logs to the file
 
 It may contain useful information.The exact location of this file may differ
 depending on your distribution and installation method. Please have this file
-ready when contacting the GVM developers through the OpenVAS mailing list
-or the online chat or submitting bug reports at
-<https://github.com/greenbone/openvas-scanner/issues> as they may help to
-pinpoint the source of your issue.
+ready when contacting the GVM developers via the Greenbone Community Portal
+or submitting bug reports at <https://github.com/greenbone/openvas/issues> as
+they may help to pinpoint the source of your issue.
 
 Logging is configured entirely by the file
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_logo_resilience_horizontal.png)
 
-# OpenVAS Scanner
+# OpenVAS
 
-[![GitHub releases](https://img.shields.io/github/release/greenbone/openvas-scanner.svg)](https://github.com/greenbone/openvas-scanner/releases)
-[![Code Documentation Coverage](https://img.shields.io/codecov/c/github/greenbone/openvas-scanner.svg?label=Doc%20Coverage&logo=codecov)](https://codecov.io/gh/greenbone/openvas-scanner)
+[![GitHub releases](https://img.shields.io/github/release/greenbone/openvas.svg)](https://github.com/greenbone/openvas/releases)
+[![Code Documentation Coverage](https://img.shields.io/codecov/c/github/greenbone/openvas-scanner.svg?label=Doc%20Coverage&logo=codecov)](https://codecov.io/gh/greenbone/openvas)
 [![CircleCI](https://circleci.com/gh/greenbone/openvas-scanner/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/openvas-scanner/tree/master)
 
-This is the Open Vulnerability Assessment System (OpenVAS) Scanner of the
+This is the Open Vulnerability Assessment Scanner (OpenVAS) of the
 Greenbone Vulnerability Management (GVM) Solution.
 
 It is used for the Greenbone Security Manager appliances and is a full-featured
@@ -22,7 +22,7 @@ This module can be configured, built and installed with following commands:
 
 For detailed installation requirements and instructions, please see the file
 [INSTALL.md](INSTALL.md). The file also contains instructions for setting up
-`openvas-scanner` and for making the scanner available to other GVM modules.
+`openvas` and for making the scanner available to other GVM modules.
 
 If you are not familiar or comfortable building from source code, we recommend
 that you use the Greenbone Community Edition, a prepared virtual machine with a
@@ -31,7 +31,7 @@ at <https://www.greenbone.net/en/community-edition/>.
 
 ## Support
 
-For any question on the usage of `openvas-scanner` please use the [Greenbone
+For any question on the usage of `openvas` please use the [Greenbone
 Community Portal](https://community.greenbone.net/c/gse). If you found a problem
 with the software, please [create an
 issue](https://github.com/greenbone/openvas-scanner/issues) on GitHub. If you
@@ -45,9 +45,9 @@ This project is maintained by [Greenbone Networks GmbH](https://www.greenbone.ne
 ## Contributing
 
 Your contributions are highly appreciated. Please [create a pull
-request](https://github.com/greenbone/openvas-scanner/pulls) on GitHub. Bigger
+request](https://github.com/greenbone/openvas/pulls) on GitHub. Bigger
 changes need to be discussed with the development team via the [issues section
-at GitHub](https://github.com/greenbone/openvas-scanner/issues) first.
+at GitHub](https://github.com/greenbone/openvas/issues) first.
 
 ## License
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,7 +196,7 @@ install (FILES ${CMAKE_SOURCE_DIR}/doc/greenbone-nvt-sync.8
 
 install (FILES ${CMAKE_BINARY_DIR}/doc/redis_config_examples/redis_3_2.conf
                ${CMAKE_BINARY_DIR}/doc/redis_config_examples/redis_4_0.conf
-         DESTINATION ${DATADIR}/doc/openvas-scanner/redis_config_examples/ )
+         DESTINATION ${DATADIR}/doc/openvas/redis_config_examples/ )
 
 install (DIRECTORY DESTINATION ${OPENVAS_NVT_DIR})
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -221,7 +221,7 @@ all_scans_are_stopped ()
 static int
 nvti_category_is_safe (int category)
 {
-  /* XXX: Duplicated from openvas-scanner/nasl. */
+  /* XXX: Duplicated from openvas/nasl. */
   if (category == ACT_DESTRUCTIVE_ATTACK || category == ACT_KILL_HOST
       || category == ACT_FLOOD || category == ACT_DENIAL)
     return 0;

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -30,7 +30,7 @@
 
 /**
  * @file
- * OpenVAS Scanner main module, runs the scanner.
+ * OpenVAS main module, runs the scanner.
  */
 
 #include "../misc/plugutils.h"     /* nvticache_free */
@@ -413,7 +413,7 @@ main (int argc, char *argv[])
     {NULL, 0, 0, 0, NULL, NULL, NULL}};
 
   option_context =
-    g_option_context_new ("- Open Vulnerability Assessment System");
+    g_option_context_new ("- Open Vulnerability Assessment Scanner");
   g_option_context_add_main_entries (option_context, entries, NULL);
   if (!g_option_context_parse (option_context, &argc, &argv, &error))
     {
@@ -432,7 +432,7 @@ main (int argc, char *argv[])
   /* --version */
   if (display_version)
     {
-      printf ("OpenVAS Scanner %s\n", OPENVAS_VERSION);
+      printf ("OpenVAS %s\n", OPENVAS_VERSION);
 #ifdef OPENVAS_GIT_REVISION
       printf ("GIT revision %s\n", OPENVAS_GIT_REVISION);
 #endif

--- a/src/openvas_log_conf.cmake_in
+++ b/src/openvas_log_conf.cmake_in
@@ -1,4 +1,4 @@
-# OpenVAS Scanner logging configuration
+# OpenVAS logging configuration
 #
 # WARNING: Setting the level of any group (besides event*) to include debug
 #          may reveal passwords in the logs.

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -266,7 +266,7 @@ pluginlaunch_init (const char *host)
   if (max_running_processes >= MAX_PROCESSES)
     {
       g_debug ("max_checks (%d) > MAX_PROCESSES (%d) - modify "
-               "openvas-scanner/openvas/pluginlaunch.c",
+               "openvas/openvas/pluginlaunch.c",
                max_running_processes, MAX_PROCESSES);
       max_running_processes = MAX_PROCESSES - 1;
     }


### PR DESCRIPTION
Only a few links to third parties still use "openvas-scanner"
since they do not react yet to the new name "openvas".