### PR TITLE
Add option --scan-stop=<scan_id>.

### DIFF
--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -41,6 +41,10 @@ Show a summary of the commands
 ID for a single scan task. The scanner will start the scan with the data already loaded in a redis KB, which will be found using the given scan-id.
 
 .TP
+.BI "--scan-stop=" <scan-uuid>
+ID for a single scan task. The scanner will search the redis kb associated to the given scan_id. It takes the pid from the kb and sends the SIGUSR2 kill signal to stop the scan.
+
+.TP
 .B "-u, --update-vt-info"
 Updates VT info into redis store from VT files.
 

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -187,6 +187,7 @@ hosts_stop_host (struct host *h)
 
   g_message ("Stopping host %s scan", h->name);
   kill (h->pid, SIGUSR1);
+  kb_delete (h->host_kb);
   return 0;
 }
 

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -370,8 +370,13 @@ start_single_task_scan ()
   scanner_thread (globals);
   exit (0);
 }
-
-void
+/**
+ * @brief Search in redis the process ID of a running scan and
+ * sends it the kill signal SIGUSR2, which will stop the scan.
+ * To find the process ID, it uses the scan_id passed with the
+ * --scan-stop option.
+ */
+static void
 stop_single_task_scan ()
 {
   char key[1024];


### PR DESCRIPTION
If openvas is started with this option and a scan_id is given, the
new function stop_single_task_scan() will be called. This function
search the redis kb associated to the scan_id. It takes the pid from
the kb and sends the SIGUSR2 kill signal to stop the scan.

Also, it removes the host kb for each stopped host.