### PR TITLE
Replace wmiexec.py with impacket-wmiexec.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,14 @@ or get the entire source code repository and view log history:
 $ git clone https://github.com/greenbone/openvas.git
 $ cd openvas && git checkout openvas-scanner-6.0 && git log
 
+openvas-scanner 6.0.2 (unreleased)
+
+This is the second patch release of the openvas-scanner module 6.0 for the
+Greenbone Vulnerability Management (GVM) framework.
+
+Main changes compared to openvas-scanner 6.0.1:
+* The call to wmiexec.py has been replaced with impacket-wmiexec, because
+  the symlink has been added in Debian Stretch with python-impacket 0.9.15-1.
 
 openvas-scanner 6.0.1 (2019-07-17)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ Recommended to have WMI support:
 * openvas-smb >= 1.0.4
 
 Recommended for extended Windows support (e.g. automatically start the remote registry service):
-* wmiexec.py of python-impacket >= 0.9.15 found within your PATH
+* impacket-wmiexec of python-impacket >= 0.9.15 found within your PATH
 
 Recommended to have improved SNMP support:
 * netsnmp

--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -392,7 +392,7 @@ nasl_win_cmd_exec (lex_ctxt *lexic)
   /* wmiexec.py uses domain/username format. */
   if ((c = strchr (username, '\\')))
     *c = '/';
-  argv[0] = "wmiexec.py";
+  argv[0] = "impacket-wmiexec";
   snprintf (target, sizeof (target), "%s:%s@%s", username, password, ip);
   argv[1] = target;
   argv[2] = cmd;


### PR DESCRIPTION
The call to wmiexec.py has been replaced with impacket-wmiexec, because
the symlink has been added in Debian Stretch with python-impacket 0.9.15-1.