### PR TITLE
Replace wmiexec.py with impacket-wmiexec. [Openvas-7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [Unreleased]: https://github.com/greenbone/openvas/compare/openvas-scanner-6.0...master
 
-## [6.0.1] (unreleased)
+## [6.0.2] (unreleased)
+
+### Changes
+- The call to wmiexec.py has been replaced with impacket-wmiexec, because the symlink has been added in Debian Stretch with python-impacket 0.9.15-1.
+
+[6.0.2]: https://github.com/greenbone/openvas/compare/v6.0.0...openvas-scanner-6.0
+
+## [6.0.1] (2019-07-17)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changes
 - The call to wmiexec.py has been replaced with impacket-wmiexec, because the symlink has been added in Debian Stretch with python-impacket 0.9.15-1.
 
-[6.0.2]: https://github.com/greenbone/openvas/compare/v6.0.0...openvas-scanner-6.0
+[6.0.2]: https://github.com/greenbone/openvas/compare/v6.0.1...openvas-scanner-6.0
 
 ## [6.0.1] (2019-07-17)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ Recommended to have WMI support:
 * openvas-smb >= 1.0.1
 
 Recommended for extended Windows support (e.g. automatically start the remote registry service):
-* wmiexec.py of python-impacket >= 0.9.15 found within your PATH
+* impacket-wmiexec of python-impacket >= 0.9.15 found within your PATH
 
 Recommended to have improved SNMP support:
 * netsnmp

--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -378,7 +378,7 @@ nasl_win_cmd_exec (lex_ctxt *lexic)
   /* wmiexec.py uses domain/username format. */
   if ((c = strchr (username, '\\')))
     *c = '/';
-  argv[0] = "wmiexec.py";
+  argv[0] = "impacket-wmiexec";
   snprintf (target, sizeof (target), "%s:%s@%s", username, password, ip);
   argv[1] = target;
   argv[2] = cmd;


### PR DESCRIPTION
The call to wmiexec.py has been replaced with impacket-wmiexec, because
the symlink has been added in Debian Stretch with python-impacket 0.9.15-1.