### PR TITLE
Vendor version is now an option in the config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A new NVT cross references data handling has been added.[#317](https://github.com/greenbone/openvas/pull/317)
 
 ### Changes
+- Vendor version is now an option in the config file. [#363](https://github.com/greenbone/openvas/pull/363)
 - The NVT preference format has been changed. [#275](https://github.com/greenbone/openvas/pull/275)
 - Redis supported versions must be 3.2 or higher. [#287](https://github.com/greenbone/openvas/pull/287)
 - Log directory is now configurable. [#316](https://github.com/greenbone/openvas/pull/316)

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -2,7 +2,7 @@
 .SH NAME
 openvas \- The Scanner of the Greenbone Vulnerability Management
 .SH SYNOPSIS
-.BI "openvas [\|-v\|] [\|-h\|]  [\|-c " config-file\| "] [\|--vendor-version " string\| "] [\|--scan-start " scan-uuid\| "]
+.BI "openvas [\|-v\|] [\|-h\|]  [\|-c " config-file\| "] [\|--scan-start " scan-uuid\| "]
 .BI " [\|-u\|] [\|-s\|] [\|-y\|]"
 
 .SH DESCRIPTION
@@ -47,10 +47,6 @@ ID for a single scan task. The scanner will search the redis kb associated to th
 .TP
 .B "-u, --update-vt-info"
 Updates VT info into redis store from VT files.
-
-.TP
-.BI "--vendor-version=" <vendor-version>
-Use the alternate vendor instead of the default one during scans.
 
 .SH THE CONFIGURATION FILE 
 
@@ -196,6 +192,9 @@ Number of checks to test at the same time it can be as low as you want it
 to be and it will also reduce network load and improve performance
 (obviously 1 is the minimum)
 Notice that OpenVAS will spawn max_hosts * max_checks processes.
+
+.IP vendor_version
+Use the alternate vendor instead of the default one during scans.
 
 Other options might be using the QoS features offered by your server
 operating system or your network to improve the bandwidth use.

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -171,7 +171,6 @@ main (int argc, char **argv)
   static gchar *trace_file = NULL;
   static gchar *config_file = NULL;
   static gchar *source_iface = NULL;
-  static gchar *vendor_version_string = NULL;
   static gboolean with_safe_checks = FALSE;
   static gboolean signing_mode = FALSE;
   static gchar *include_dir = NULL;
@@ -201,8 +200,6 @@ main (int argc, char **argv)
      "Configuration file", "<filename>"},
     {"source-iface", 'e', 0, G_OPTION_ARG_STRING, &source_iface,
      "Source network interface for established connections.", "<iface_name>"},
-    {"vendor-version", '\0', 0, G_OPTION_ARG_STRING, &vendor_version_string,
-     "Use <string> as vendor version.", "<string>"},
     {"safe", 's', 0, G_OPTION_ARG_NONE, &with_safe_checks,
      "Specifies that the script should be run with 'safe checks' enabled",
      NULL},
@@ -284,9 +281,6 @@ main (int argc, char **argv)
       exit (1);
     }
 
-  if (vendor_version_string)
-    vendor_version_set (vendor_version_string);
-
   if (!(mode & (NASL_EXEC_PARSE_ONLY | NASL_LINT)) && geteuid ())
     {
       fprintf (stderr, "** WARNING : packet forgery will not work\n");
@@ -334,6 +328,10 @@ main (int argc, char **argv)
     }
 
   prefs_config (config_file ?: OPENVAS_CONF);
+
+  if (prefs_get ("vendor_version") != NULL)
+    vendor_version_set (prefs_get ("vendor_version"));
+
   while ((host = gvm_hosts_next (hosts)))
     {
       struct in6_addr ip6;

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -124,6 +124,7 @@ static openvas_option openvas_defaults[] = {
   // prefs_init.
   {"report_host_details", "yes"},
   {"db_address", KB_PATH_DEFAULT},
+  {"vendor_version", "\0"},
   {NULL, NULL}};
 
 gchar *unix_socket_path = NULL;
@@ -413,7 +414,6 @@ openvas (int argc, char *argv[])
 
   static gboolean display_version = FALSE;
   static gchar *config_file = NULL;
-  static gchar *vendor_version_string = NULL;
   static gchar *scan_id = NULL;
   static gchar *stop_scan_id = NULL;
   static gboolean print_specs = FALSE;
@@ -426,8 +426,6 @@ openvas (int argc, char *argv[])
      "Display version information", NULL},
     {"config-file", 'c', 0, G_OPTION_ARG_FILENAME, &config_file,
      "Configuration file", "<filename>"},
-    {"vendor-version", '\0', 0, G_OPTION_ARG_STRING, &vendor_version_string,
-     "Use <string> as vendor version.", "<string>"},
     {"cfg-specs", 's', 0, G_OPTION_ARG_NONE, &print_specs,
      "Print configuration settings", NULL},
     {"sysconfdir", 'y', 0, G_OPTION_ARG_NONE, &print_sysconfdir,
@@ -487,9 +485,6 @@ openvas (int argc, char *argv[])
 
   unix_socket_path = g_build_filename (OPENVAS_RUN_DIR, "openvas.sock", NULL);
 
-  if (vendor_version_string)
-    vendor_version_set (vendor_version_string);
-
   if (!config_file)
     config_file = OPENVAS_CONF;
   if (update_vt_info)
@@ -503,6 +498,9 @@ openvas (int argc, char *argv[])
 
   if (init_openvas (config_file))
     return 1;
+
+  if (prefs_get ("vendor_version") != NULL)
+    vendor_version_set (prefs_get ("vendor_version"));
 
   if (stop_scan_id)
     {

--- a/src/utils.c
+++ b/src/utils.c
@@ -157,6 +157,7 @@ is_scanner_only_pref (const char *pref)
       || !strcmp (pref, "log_whole_attack")
       || !strcmp (pref, "log_plugins_name_at_load")
       || !strcmp (pref, "nasl_no_signature_check")
+      || !strcmp (pref, "vendor_version")
       /* Preferences starting with sys_ are scanner-side only. */
       || !strncmp (pref, "sys_", 4))
     return 1;


### PR DESCRIPTION
Remove vendor-version cmd argument and use config file option instead.
Since openvas is called from ospd-openvas, and the only argument passed is the scan-id.
If a vendor version is desired, it must be set in the config file.