### PR TITLE
Fix typos, change tabs to spaces and strip trailing whitespaces.

### DIFF
--- a/CHANGES-OLD
+++ b/CHANGES-OLD
@@ -366,7 +366,7 @@ Main changes compared to 5.0+beta3:
   of immediately bailing out.
 * Considerable reduction of memory consumption.
 * Various code cleanups and improvements.
-* Increase buffer size for preferences to allow for upto 69K NVTs.
+* Increase buffer size for preferences to allow for up to 69K NVTs.
 * Log backtrace when a process segfaults.
 * Refactored preferences module.
 
@@ -453,7 +453,7 @@ Hani Benhabiles, Jan-Oliver Wagner
 
 Main changes compared to 4.0.0:
 * Remove "beta" from OTP identifier.
-* Remove superflous linking.
+* Remove superfluous linking.
 
 
 openvas-scanner 4.0.0 (2014-04-10)
@@ -500,7 +500,7 @@ Main changes compared to 3.4.x:
 * The port range option "default" has been removed.
 * The scanner preference "silent_dependencies" has been removed.
 * Improved port range validation.
-* Prevent NVT circular depedencies in recursion.
+* Prevent NVT circular dependencies in recursion.
 * Removed support for OVAL plugins. It was never used as part of the feed
   and it makes more sense to issue a specialised oval scanner.
 * The host permissions concept has been reworked, resulting in the removal of
@@ -608,7 +608,7 @@ This is the fifth beta release of the openvas-scanner 4.0 module for the Open
 Vulnerability Assessment System (OpenVAS). It will be part of the upcoming
 "OpenVAS-7".
 
-Main changes since last beta release address some fixes and code cleanups. 
+Main changes since last beta release address some fixes and code cleanups.
 
 Many thanks to everyone who has contributed to this release:
 Hani Benhabiles, Henri Doreau, Michael Meyer, Matthew Mundell,
@@ -617,7 +617,7 @@ Michael Wiegand and Jan-Oliver Wagner.
 Main changes compared to 4.0+beta4:
 * Don't early drops out of OTP upon non-critical problems.
 * Improved port range validation.
-* Prevent NVT circular depedencies in recursion.
+* Prevent NVT circular dependencies in recursion.
 * Code cleanups.
 
 
@@ -702,7 +702,7 @@ Vulnerability Assessment System (OpenVAS). It will be part of the upcoming
 
 Main new features and other changes of 4.0 compared to 3.4 include:
 Functionality such as user and rules management has been moved to OpenVAS
-Manger and removed from OpenVAS Scanner. As a result, other now superfluous
+Manager and removed from OpenVAS Scanner. As a result, other now superfluous
 functionality has been removed as well, along with a number of legacy features
 conflicting with the updated behavior of OpenVAS Scanner. The OTP version
 number has been increased to reflect the resulting protocol changes.
@@ -867,7 +867,7 @@ Main changes compared to 3.3+beta2:
 * Don't start the second scan phase when network scan is enabled and
   user requests "stop" during the first phase.
 * Send an ERRMSG to the client when terminating a process.
-* Furter improvements to the build system.
+* Further improvements to the build system.
 
 
 openvas-scanner 3.3+beta2 (2011-10-10)
@@ -1299,7 +1299,7 @@ Vlatko Kosturjak, Matthew Mundell, Jan-Oliver Wagner, Michael Wiegand and Felix
 Wolfsteller.
 
 Main changes compared to 3.0.0:
-* Reenabled certificate authentication
+* Re-enabled certificate authentication
 * Improved user rules support
 * Updated openvas-nvt-sync script
 
@@ -1620,7 +1620,7 @@ Version 3.0 prepares the new OpenVAS Manager and OpenVAS Administrator
 as optional extension. This combination leverages the vulnerability
 scanner to a comprehensive vulnerability management solution.
 
-The "beta" releases are intented to allow testing of the upcoming
+The "beta" releases are intended to allow testing of the upcoming
 3.0 series. It should be kept separate from OpenVAS 2.0 installations
 and not be used in a production environment.
 
@@ -1669,7 +1669,7 @@ Version 3.0 prepares the new OpenVAS Manager and OpenVAS Administrator
 as optional extension. This combination leverages the vulnerability
 scanner to a comprehensive vulnerability management solution.
 
-The "beta" releases are intented to allow testing of the upcoming
+The "beta" releases are intended to allow testing of the upcoming
 3.0 series. It should be kept separate from OpenVAS 2.0 installations
 and not be used in a production environment.
 
@@ -1830,7 +1830,7 @@ Main changes since 2.0-rc1:
 Main changes since 1.0.1:
 * Support for the new script_tag command in NASL scripts has been added.
 * 64-bit compatibility has been considerably improved.
-* Support for transfering NVT signature information to the client has been added.
+* Support for transferring NVT signature information to the client has been added.
 * Certificate checking has been improved.
 * The obsolete openvas-check-signature tool has been removed.
 * Support for plugin upload has been removed from OpenVAS-Server.
@@ -1894,7 +1894,7 @@ OpenVAS website.
 Main changes since 2.0-beta1:
 * 64-bit compatibility has been considerably improved.
 * Debian packaging files have been updated.
-* Support for transfering NVT signature information to the client has been added.
+* Support for transferring NVT signature information to the client has been added.
 * Certificate checking has been improved.
 * OVAL support has been improved.
 * The obsolete openvas-check-signature tool has been removed.
@@ -1957,7 +1957,7 @@ Please be aware that the plugin upload feature has been disabled in
 openvas-server due to security concerns as described in
 http://www.openvas.org/openvas-cr-4.html . This functionality is now deprecated
 and will be removed in future versions of openvas-server. If your existing
-installation depends on this feature, we recommend that you do not update to 
+installation depends on this feature, we recommend that you do not update to
 1.0.1.
 
 * Added syslog support to openvasd logging facility.
@@ -2033,7 +2033,7 @@ Main changes are:
 * SSL now mandatory.
 * Many cleanups of ancient remains (still many to come)
 * Removed various W32-specific elements, because W32 isn't
-  a taget system anyway.
+  a target system anyway.
 * Lots of renaming to avoid conflicts with parallel
   Nessus installation
 
@@ -2054,10 +2054,10 @@ Old Changes information from the Nessus times:
 
 . changes by Michel Arboi :
 
-- nessus_tcp_scanner now tracks down more statistics about the remote ports 
+- nessus_tcp_scanner now tracks down more statistics about the remote ports
   (filtered vs. closed)
 
-. changes by Beirne Kornarksi : 
+. changes by Beirne Kornarksi :
 
 - Fixed bug#1224
 
@@ -2114,9 +2114,9 @@ Old Changes information from the Nessus times:
 (only HTTP-related sockets would have a buffered input)
 
 - Fixed bug#1065 which would make nessusd do an endless stream of calls
-to gethostbyname() when testing a non-existant host name 
+to gethostbyname() when testing a non-existent host name
 
-- Fixed a bug in the TCP socket buffering which would cause 
+- Fixed a bug in the TCP socket buffering which would cause
 read_stream_connection() to perform a short read under some circumstances
 
 - Added nessus-fetch(1), a utility which retrieves plugins from
@@ -2142,7 +2142,7 @@ of wget/lynx/fetch/curl
 
 - Fixed a bug in the client which would not make it 'remember' the scanner selection
 - Each plugin can have a bigger number of cross-references associated to it
-- Starting nessusd displays the current status of the plugins beeing loaded
+- Starting nessusd displays the current status of the plugins being loaded
 
 . changes by Boris Wolf :
 
@@ -2156,7 +2156,7 @@ of wget/lynx/fetch/curl
   of re-establishing the connection
 - New system calls in NASL - get_kb_fresh_item() and replace_kb_item()
 - The SSH checks now use a shared socket instead of re-logging into the
-  remote host 
+  remote host
 - The plugin selection in the client GUI is much faster
 
 
@@ -2185,12 +2185,12 @@ signed before uncompressing it
 - Scripts can be cryptographically signed. A signed script gets access to
 more NASL functions
 
-- Restricted the access to the nasl functions pem_to_rsa(), pem_to_dsa(), 
+- Restricted the access to the nasl functions pem_to_rsa(), pem_to_dsa(),
 rsa_sign() and dsa_do_sign() to signed NASL scripts
 
 - The nasl functions pread() and find_in_path() are accessible to
 signed NASL scripts and allow the execution of local commands
- 
+
 
 2.1.0 :
 
@@ -2213,17 +2213,17 @@ to support KB items of arbitrary length
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
-- Fixed a bug in ./configure which would sometimes assume that GTK is not 
+- Fixed a bug in ./configure which would sometimes assume that GTK is not
 installed whereas it actually is
 - Fixed a race condition in nessus-adduser for users who do not configure
 their TMPDIR variable (thanks to Cyrille Barthelemy)
-- Fixed a bug in nessus-update-plugins which would not update the plugins 
+- Fixed a bug in nessus-update-plugins which would not update the plugins
 properly on all systems
 - Fixed the installer to compile Nessus with GTK support if gtk-config OR
 pkg-config is installed.
 
 
-2.0.11 : 
+2.0.11 :
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
@@ -2251,7 +2251,7 @@ pkg-config is installed.
 
 . changes by (galt@fiberpimp.net)
 
-- IP addresses are now sorted in EVERY reports 
+- IP addresses are now sorted in EVERY reports
 
 . changes by Laurent FACQ (facq@u-bordeaux.fr)
 
@@ -2279,9 +2279,9 @@ pkg-config is installed.
 - All SSL operations now use non-blocking sockets instead of the alarm()
   trick to handle timeouts
 
-. Changes by Pavel Kankovky 
+. Changes by Pavel Kankovky
 
-- Minimize the number of pixmaps that need to be created in the Nessus 
+- Minimize the number of pixmaps that need to be created in the Nessus
   client by re-using them
 
 2.0.8 :
@@ -2318,7 +2318,7 @@ pkg-config is installed.
 - Support for the keyword 'default' as a port range in nmap_wrapper.nes
 - Fixed a zombie issue in nmap_wrapper.nes
 - Fixed various issues which could allow a NASL script to crash the
-  NASL interpretor
+  NASL interpreter
 - Improved the process management in find_services.nes
 
 2.0.5 :
@@ -2380,7 +2380,7 @@ pkg-config is installed.
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
-- Re-wrote webmirror.nasl from scratch. The new version has a real parser 
+- Re-wrote webmirror.nasl from scratch. The new version has a real parser
   built-in and is much faster
 
 - Added checks for older Microsoft Advisories
@@ -2394,11 +2394,11 @@ pkg-config is installed.
 
 - Fixed IP ranges notation (10.1.1-9.1-254 did not work any more)
 
-- Minor bug fixes and enhancements : #234, #233, #230, #229, #228, #225, #222, 
+- Minor bug fixes and enhancements : #234, #233, #230, #229, #228, #225, #222,
   #220, #218, #217, #216, #215, #213, #212, #211, #207, #206, #205
 
 - nessus-update-plugins properly calls chown under FreeBSD, no matter how
-  many plugins there are 
+  many plugins there are
 
 - find_services.nes recognizes even more protocols
 
@@ -2433,11 +2433,11 @@ pkg-config is installed.
 
 . changes by Michel Arboi (arboi@alussinan.org)
 
-- NASL2 : Implement >!< "strings don't match" operator 
+- NASL2 : Implement >!< "strings don't match" operator
 - NASL2 : fixed a vicious case of freed memory copy.
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
-  
+
 - Fixed a small bug in the plugin scheduler
 - Ported to IRIX
 - Several small bugfixes
@@ -2455,7 +2455,7 @@ pkg-config is installed.
 - Re-written the process manager for the hosts
 - Lots of bugfixes in the plugins text store manager
 - New port scanner "synscan" which uses the RTT of the packets to do
-  its job. 
+  its job.
 - Fixed several small issues in nasl and nessusd (bug fixes, code cleanup)
 - Added cryptographic hashing functions in NASL
 - Added the function get_kb_list() which returns the content of a KB
@@ -2484,19 +2484,19 @@ pkg-config is installed.
   the consumption of the nessus daemon of two megs. This also speeds up
   the loading of nessusd.
 
-- Fixed a bug in the plugins scheduler (if optimizations were enabled, 
+- Fixed a bug in the plugins scheduler (if optimizations were enabled,
   the scan would sometime hang)
 
 - Added a new NASL function (int())
 
-- Fixed strings substraction to handle null values properly
+- Fixed strings subtraction to handle null values properly
 
 - find_services.nes runs in parallel mode, for improved speed
 
 - new plugin (synscan) which should perform well against firewalled
   hosts (computes the RTT before the scan)
 
-1.3.2 : 
+1.3.2 :
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
@@ -2512,12 +2512,12 @@ pkg-config is installed.
 - Improved tcp_ping()
 
 - Fixed two bugs in the plugins scheduler :
-	- If the option "enable dependencies at runtime" is set, 
-	  it would enable ALL the plugins which are depended on, instead
-	  of only those we use ;
+  - If the option "enable dependencies at runtime" is set,
+  it would enable ALL the plugins which are depended on, instead
+  of only those we use;
 
-	- In some cases, it may terminate too early, thus preventing a scan
-	  from being complete
+  - In some cases, it may terminate too early, thus preventing a scan
+  from being complete
 
 - DESTDIR support
 
@@ -2530,12 +2530,12 @@ pkg-config is installed.
   but as a result, it is not possible to accurately determine the
   order in which the plugins will be ran, so the 'plugin name' in
   the client is now totally bogus
-  
+
 - Fixed various issues with NASL scripts so that they work better
   with NASL2
 
 - Fixed bugs relative to the creation of icmp and udp packets in nasl
-  
+
 - Fixed some fatal bugs in the bpf sharer
 
 - NASL scripts do not read /dev/urandom any more, and use time() as a
@@ -2544,7 +2544,7 @@ pkg-config is installed.
 
 - Fixed the tcp NIDS evasion techniques on BSD systems
 
-- Full support for Bugtraq IDs 
+- Full support for Bugtraq IDs
 
 - The HTML reports add links for URLs, and show the ID number of
   the plugin that issues the report.
@@ -2558,7 +2558,7 @@ pkg-config is installed.
 
 - Better handling of the arrays in NASL2
 
-. changes by Erik Anderson (eanders@carmichaelsecurity.com) 
+. changes by Erik Anderson (eanders@carmichaelsecurity.com)
 
 - CVE and bugtraq cross references
 
@@ -2569,7 +2569,7 @@ pkg-config is installed.
 . changes by Javier Fernandez-Sanguino (jfernandez@germinus.com)
 
 - Nessus now ships Hydra 2.2
-- Fixed various compilation scritps (see bug#63)
+- Fixed various compilation scripts (see bug#63)
 
 1.3.0 :
 
@@ -2585,11 +2585,11 @@ pkg-config is installed.
 
 - The 'cancel' button of several file selection dialogs is now working
 - Optimized several plugins :
-	- Web-related checks now use http_recv() instead of recv()
-	- open_priv_sock_tcp() has a lower timeout
-	- RPC related checks now use get_rpc_port(), a function equivalent
-	  to libc's getrpcport() but with a much smaller timeout
-	- Decreased the default value of checks_read_timeout from 15 to 5
+  - Web-related checks now use http_recv() instead of recv()
+  - open_priv_sock_tcp() has a lower timeout
+  - RPC related checks now use get_rpc_port(), a function equivalent
+  to libc's getrpcport() but with a much smaller timeout
+  - Decreased the default value of checks_read_timeout from 15 to 5
 - Fixed a bug in the plugin selection GUI which would not refresh
   the list of plugins of a given family properly (bug#3)
 - Fixed memory leaks in NASL
@@ -2598,7 +2598,7 @@ pkg-config is installed.
 - Fixed a compatibility problem with Nmap 3.10ALPHA (bug#11)
 - Nessus now accepts nmap's U: and T: notation for the port range (bug#5)
 - Helped Michel Arboi to give the last touches to the new libnasl
-  
+
 . changes by Erik Anderson (eanders@pobox.com)
 
 - Added CVE and BID links, added urls and removed dead links from the plugins
@@ -2631,7 +2631,7 @@ pkg-config is installed.
 - find_service now detects services protected by TCP wrappers or ACL
 - find_service detects gnuserv
 - ptyexecvp() replaced by nessus_popen() (*)
-  
+
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
 - Fixed a bug which may make nasl interpret backquoted strings
@@ -2653,8 +2653,8 @@ pkg-config is installed.
 
 
 (*) These two modifications solve the problems of nmap hanging under FreeBSD
-  
-  
+
+
 1.2.5 :
 
 . changes by Michel Arboi (arboi@alussinan.org)
@@ -2674,7 +2674,7 @@ pkg-config is installed.
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
-- Reverted back to autoconf 2.13. 
+- Reverted back to autoconf 2.13.
 - Bug fix in nessus-core/nessusd/pluginlaunch.c - under some circumstances,
   data might have be lost in the reports
 - Fixed a bug in several plugins for web checks (under some circumstances,
@@ -2697,7 +2697,7 @@ pkg-config is installed.
 
 - Fixed a bug which could make, under some circumstances, make nessusd
   crash the host it is running on.
-- If the option log_whole_attack is set to "no", then only the begining
+- If the option log_whole_attack is set to "no", then only the beginning
   and the end of the attack is logged (and not the time each plugin takes)
 - Improved no404.nasl to further reduce false positives
 - Bug fix in nessusd - under some rare circumstances, report data could
@@ -2715,9 +2715,9 @@ pkg-config is installed.
 
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
-- In the GUI, while running a scan, plugins names are only updated once 
+- In the GUI, while running a scan, plugins names are only updated once
   in a while (saves CPU)
-- Bugfix in the client : some host names would make the client crash 
+- Bugfix in the client : some host names would make the client crash
 - Repaired the '-P' switch in the client
 
 1.2.1 :
@@ -2734,7 +2734,7 @@ pkg-config is installed.
 . changes by Renaud Deraison (deraison@cvs.nessus.org)
 
 - Fixed the -i switch of nessus-update-plugins
-- Fixed a bug in the server which would, in some circumstances, not make it 
+- Fixed a bug in the server which would, in some circumstances, not make it
   announce the proper order of the plugins being run
 - More CVE cross references
 - get_host_name() always return a FQDN
@@ -2759,7 +2759,7 @@ pkg-config is installed.
 
 . changes by Nicolas Dubee (ndubee@secway.com) :
 
-- Better support for AF_UNIX sockets 
+- Better support for AF_UNIX sockets
 
 
 . changes by Brian (bmc@snort.org) :
@@ -2769,7 +2769,7 @@ pkg-config is installed.
 
 . changes by Peter Gründl (pgrundl@kpmg.dk) and
   Carsten Joergensen (carstenjoergensen@kpmg.dk) :
-  
+
 - Extensive review of the plugins and therefore numerous fixes
 
 . changes by Axel Nennker (Axel.Nennker@t-systems.com)
@@ -2779,22 +2779,22 @@ pkg-config is installed.
 . changes by Renaud Deraison (deraison at nessus.org)
 
 - It is now possible to upload files to the server when using
-  the command line client 
+  the command line client
 
 - lrand48() portability problems worked around
 
 - fixed a bug in the report window that would make it crash
   randomly
-  
 
 
-  
+
+
 1.1.14 :
 
 . changes by Renaud Deraison (deraison at nessus.org)
 
 - SMB fixes (thanks to Michael Scheidell)
-- When the safe checks option is enabled, dangerous tests with no 
+- When the safe checks option is enabled, dangerous tests with no
   alternate code (ie: plugins of type ACT_DESTRUCTIVE_ATTACK and
   ACT_DENIAL) are disabled
 - Hosts can be designated by their MAC address of instead of their
@@ -2872,7 +2872,7 @@ pkg-config is installed.
   in it
 - Plugins now have versions numbers.
 - The user can upload his plugins to the nessusd server from the client
-- It is now possible to upload files to the server (ie: nmap's results) in 
+- It is now possible to upload files to the server (ie: nmap's results) in
   command-line mode
 - Fixed false positives in SNMP plugins when launched against a non-configured
   Solaris snmpd
@@ -2885,12 +2885,12 @@ pkg-config is installed.
 
 . changes by Renaud Deraison (deraison at nessus.org)
 
-- Fixed a bug introduced in 1.1.9 which would sometimes prevent a user from 
+- Fixed a bug introduced in 1.1.9 which would sometimes prevent a user from
   aborting an on-going test
 - Fixed a bug in the client which would prevent the user from setting a port
   range longer than 255 chars
 - Fixed bugs in pcap_next() (thanks to Richard van den Berg). Also, pcap_next()   is now more flexible.
-- Fixed a bug in the command line client which would make it close the 
+- Fixed a bug in the command line client which would make it close the
   communication too early when the client - server communication is not
   ciphered
 - Added an "auto-load dependencies at runtime" option
@@ -2902,7 +2902,7 @@ pkg-config is installed.
 
 - Fix in the GUI, when closing a saved report
 - Fixed a bug in ftp_log_in() which would prevent nasl script from
-  logging into some FTP servers 
+  logging into some FTP servers
 - Solaris build problems fixed
 - Darwin 1.4.1 build problems fixed
 - MkLinux DR3 build problems fixed  (is anyone using it anymore ?)
@@ -2937,7 +2937,7 @@ pkg-config is installed.
 - Fixed the reporting of the client (reports would be mixed)
 - Client removes tempfiles when exiting
 - Repaired ptyexecvp() which would not work on Solaris
-- Slight bugfix in the NASL interpretor
+- Slight bugfix in the NASL interpreter
 
 . changes by Georges Dagousset (georges at alert4web.com)
 
@@ -2956,7 +2956,7 @@ pkg-config is installed.
 
 - Compiles on platforms without OpenSSL
 - Better Solaris support
-- Ported under Darwin (many thanks to Dieter Fiebelkorn 
+- Ported under Darwin (many thanks to Dieter Fiebelkorn
   (dieter at fiebelkorn.net) who actually started the port and helped
   me test this)
 - Unscanned ports can now be considered as closed or open (instead of
@@ -2993,7 +2993,7 @@ pkg-config is installed.
 - When an host could not be pinged, his KB is not altered (nor created)
 - fixed memory leaks in nessusd
 - nessus-mkcert checks that the certificates were really created
-  before congratulating the user 
+  before congratulating the user
 - fixed a security problem where anybody with a shell on the nessusd
   host could log in
 
@@ -3034,7 +3034,7 @@ pkg-config is installed.
 - fixed find_services.nes
 - plugins that are slow to finish are _really_ killed by the server
 - the client better handles the scan of big networks
-- nmap_wrapper now updates its progress bar 
+- nmap_wrapper now updates its progress bar
 - nessus-update-plugins support proxies (with or without authentication)
 - monitor_backend.c and data_mining.c allow any developer to plug
   a database behind the client (by default flatfiles are used)
@@ -3047,7 +3047,7 @@ pkg-config is installed.
 . changes by Michel Arboi (arboi@alussinan.org) :
 
 - find_services accepts password-protected .pem files
-- patches in the way files were transmitted between the client 
+- patches in the way files were transmitted between the client
   and the server (which could end up in a deadlock)
 
 . changes by Alexis de Bernis <alexisb at tpfh.org) :
@@ -3084,17 +3084,17 @@ pkg-config is installed.
 - corrected a bug introduced in 1.1.0 that would make the client not display
   the name of the plugin currently being run.
 - sending signal SIGUSR1 to nessusd makes the grandfather process (the one
-  who listens on tcp ports) die without killing its children, thus 
+  who listens on tcp ports) die without killing its children, thus
   allowing a smooth upgrade of nessusd
 - updated config.guess and config.sub
-  
+
 1.1.1 :
 
 . changes by Renaud Deraison (deraison at nessus.org) :
 
 - fixed mem leaks in NASL
 - fixed a bug introduced in 1.1.0 regarding recv_line()
-- fixed a bug introduced in 1.1.0 in the process management of the plugins 
+- fixed a bug introduced in 1.1.0 in the process management of the plugins
   (all the KB would not be filled, resulting in incomplete tests)
 - smb_sid2user.nasl is twice as fast ;)
 
@@ -3203,7 +3203,7 @@ pkg-config is installed.
 
 . changes by Loren Bandiera (lorenb at shelluser.net) :
 
-- XML output in the Nessus client. 
+- XML output in the Nessus client.
 
 . changes by Renaud Deraison (deraison at nessus.org) :
 
@@ -3211,7 +3211,7 @@ pkg-config is installed.
   from scratch between two tests. See http://www.nessus.org/doc/kb_saving.html
   for details
 
-- added experimental detached scans. 
+- added experimental detached scans.
   See http://www.nessus.org/doc/detached_scan.html for details
 
 - bug in the test of DoS attacks fixed (thanks to Christophe Grenier,
@@ -3233,7 +3233,7 @@ pkg-config is installed.
 - libnasl : better error reporting, minor bugs fixed
 
 
-. Changes by Jordan Hrycaj (jordan at mjh.teddy-net.com) 
+. Changes by Jordan Hrycaj (jordan at mjh.teddy-net.com)
 
 - faster cipher layer
 
@@ -3264,7 +3264,7 @@ pkg-config is installed.
 - better handling of large reports
 
 - tests are saved on the server side and can be restored. Note that
-  this is experimental and disabled by default. Do 
+  this is experimental and disabled by default. Do
   ./configure --enable-save-sessions to enable this experimental
   feature, and read doc/session_saving.txt for details.
 
@@ -3292,14 +3292,14 @@ pkg-config is installed.
 - possible header confusion (with regex.h) fixed
 
 - possible signal deadlock when exiting fixed
-  
+
 . Other changes :
 
 - fixed a problem in the function is_cgi_installed() that may sometime
   not work against odd clients (Thomas Reinke (reinke at e-softinc.com))
 
 - fixed a bug in snmp_default_communities.nasl (Lionel Cons (lionel.cons at cern.ch))
-  
+
 - fixed showmount.nasl (Paul Ewing Jr. (ewing at ima.umn.edu))
 
 - typo in showmount.nasl would prevent it to work over udp (ctor at krixor.xy.org)
@@ -3336,8 +3336,8 @@ pkg-config is installed.
 
 - plugins: finger.nasl was buggy
 
-. changes by Renaud Deraison (renaud at nessus.org) : 
- 
+. changes by Renaud Deraison (renaud at nessus.org) :
+
 - possible hang at report time fixed in the client
 
 - fixed a bug in the way the command-line client handles the plugins
@@ -3346,18 +3346,18 @@ pkg-config is installed.
 - fixed a problem in the detection of the servers that do not reply
   with a 404 error code when request an inexistant page
 
-- fixed various compilations errors occuring on various
+- fixed various compilations errors occurring on various
   platforms
 
 - libnasl : fixed a bug that would occur in standalone mode
 
 - nessus-libraries : takes the presence of the shared libraries
   of the system into account
-  
+
 - SMB and DCE/RPC over SMB issues :
 
    . smb_login.nasl : fixed an error (would always want
-     to access IPC$ to declare that a login is valid)  
+     to access IPC$ to declare that a login is valid)
 
    . netbios_name_get.nasl : fixed an error which would
      prevent the SMB tests to work against Windows 2000
@@ -3372,26 +3372,26 @@ pkg-config is installed.
 - new security checks added
 
 
-. changes by Jordan Hrycaj (jordan at nessus.org) : 
+. changes by Jordan Hrycaj (jordan at nessus.org) :
 
-- libpeks now uses the libgmp that comes with the operating system 
+- libpeks now uses the libgmp that comes with the operating system
   if any, and does the same for libz
-  
+
 - fixed a bug that would prevent the client from working properly
   under OpenBSD
-  
+
 1.0.1 :
 
-- nessusd : if the --enable-tcpwrappers flag is given to 
+- nessusd : if the --enable-tcpwrappers flag is given to
   ./configure, then nessusd is compiled with tcpwrappers support
 
 - nessus : Pies and charts under Win32 too
 
 - nessus : fixed errors when generating pies and charts which would
   cause horrible graphics (thanks to John Q. Public (tpublic at dimensional.com)
-  for pointing this out)    
+  for pointing this out)
 
-- nasl : memory leaks fixed, performance improved, bug in 
+- nasl : memory leaks fixed, performance improved, bug in
   forge_tcp_packet() fixed
 
 - nessus-update-plugins : somehow improved
@@ -3402,7 +3402,7 @@ pkg-config is installed.
 - plugins : fixed snmp_default_communities which was bugged. Thanks to
   W. Mark Herrick, Jr. (markh at va.rr.com) for pointing this out.
 
-- gmp 3.0 is used by libpeks (vs 2.0.2)  
+- gmp 3.0 is used by libpeks (vs 2.0.2)
 
 1.0.0 :
 
@@ -3425,9 +3425,9 @@ pkg-config is installed.
 
 - nessus : HTML reports now include links to the CVE entries
 
-- nessus-adduser / libpeks : it is now possible to declare 
-  from which host a user can connect to nessusd 
-  
+- nessus-adduser / libpeks : it is now possible to declare
+  from which host a user can connect to nessusd
+
 - plugins : better behavior of the CGI tests against hosts
   which do not issue 404 error codes
 
@@ -3436,11 +3436,11 @@ pkg-config is installed.
   arbitrary files on the system
 
 - nessusd : sends an error to the client when it attempts to scan
-  a host it's not allowed to (suggested by Hermann Himmelbauer 
+  a host it's not allowed to (suggested by Hermann Himmelbauer
   <dusty@violin-kan.dyndns.org>)
 
 - nessusd and nessus : error at loading time when the peks library was
-  compiled with a special ./configure flag (thanks to 
+  compiled with a special ./configure flag (thanks to
   Bradley M Alexander <storm@tux.org>)
 
 - nessusd and nessus : can be compiled with the --disable-cipher flags
@@ -3449,23 +3449,23 @@ pkg-config is installed.
   by Jean-Paul Le Fevre <J-P.LeFevre@cea.fr>
 
 - plugins : a dozen of new plugins have been added (piranha, uw imap
-  overflow, Ken!, htimage.exe, lcdproc overflow, real server DoS, and 
+  overflow, Ken!, htimage.exe, lcdproc overflow, real server DoS, and
   more...)
 
-- nasl : added open_priv_sock_{udp,tcp} to open a socket with a priviledged
+- nasl : added open_priv_sock_{udp,tcp} to open a socket with a privileged
   port
 
-  
+
 1.0.0pre2 :
 
 
 - nessusd : stop the current plugin when the user hits 'stop'
 
 - nessusd : the rules now accept the keyword 'client_ip'  (suggested
-  by  Hermann Himmelbauer <dusty@violin-kan.dyndns.org>)  
+  by  Hermann Himmelbauer <dusty@violin-kan.dyndns.org>)
 
-- nessusd : logs the name of the plugins that are loaded (suggested 
-  by Matthias Andree <ma@dt.e-technik.uni-dortmund.de>)  
+- nessusd : logs the name of the plugins that are loaded (suggested
+  by Matthias Andree <ma@dt.e-technik.uni-dortmund.de>)
 - nessus : the 'reverse lookup' option now works
 
 - nessus : typo would prevent to compile nessus with gtk 1.0 (thanks to
@@ -3491,7 +3491,7 @@ pkg-config is installed.
 - nessus : other cosmetics things have been fixed
 
 - nasl : now supports user-defined functions (see the documentation
-  for more details)  
+  for more details)
 
 - plugins : ssh_insertion.nasl : fixed a typo which would cause the plugin
   to yell when the user was using OpenSSH 1.2.2 (which is immune to this
@@ -3523,14 +3523,14 @@ pkg-config is installed.
 - nessusd : fixed a problem in the rules which ended up being
   too restrictive
 
-- nessusd : killall -1 nessusd now works  
+- nessusd : killall -1 nessusd now works
 
 - plugins : nmap_wrapper.nes : compatible with the new output of nmap
 
 - traditional netmasks (255.255.255.0) are now accepted
 
-- will not scan broadcast addresses (ie: 192.168.1.1/255.255.255.0 will scan 
-  from 192.168.1.1 to 192.168.1.254)  
+- will not scan broadcast addresses (ie: 192.168.1.1/255.255.255.0 will scan
+  from 192.168.1.1 to 192.168.1.254)
 
 
 - Compatible with FreeBSD 4
@@ -3542,8 +3542,8 @@ pkg-config is installed.
 - nessus : GTK 1.0 compatible (Eduardo Urrea <eduardou@hispasecurity.com>)
 
 - nessusd : fixed a problem which could make the client see what was
-  happening a few seconds later the event happened. (this was occuring
-  when doing few tests against a great number of hosts)    
+  happening a few seconds later the event happened. (this was occurring
+  when doing few tests against a great number of hosts)
 
 - nessusd.conf goes back to ${sysconfdir}/nessus/ (and not
   ${sysconfdir}/)
@@ -3552,7 +3552,7 @@ pkg-config is installed.
   Ryan Mooney <ryanm@mhpcc.edu> who pointed this out]
 
 - nessus and nessusd : the target file may have an unlimited size
-  (it was cut down to 2047 bytes in the past) [many thanks to 
+  (it was cut down to 2047 bytes in the past) [many thanks to
   Boris Wesslowski <Boris.Wesslowski@RUS.Uni-Stuttgart.DE> for pointing
   this out]
 
@@ -3561,12 +3561,12 @@ pkg-config is installed.
 
 - nasl : close the sockets opened by a script in nasl_exit()
 
-- nasl : fixed a bug in egrep()  
+- nasl : fixed a bug in egrep()
 
-- nasl : init_telnet() behaves well against a tcp-wrapped telnet  
+- nasl : init_telnet() behaves well against a tcp-wrapped telnet
 
 - plugins : nmap_wrapper : ability to use nmap's ping.
-  
+
 0.99.9 :
 
 
@@ -3589,9 +3589,9 @@ pkg-config is installed.
 
 - nessus :  disable all / enable all buttons
 
-- nessus : nicer xpms for error and warnings dialogs 
+- nessus : nicer xpms for error and warnings dialogs
 
-- nessus : fixed a bug that could make the client crash during plugin 
+- nessus : fixed a bug that could make the client crash during plugin
   selection
 
 - plugins : read_accounts : fixed a problem that would disable  this plugin
@@ -3602,7 +3602,7 @@ pkg-config is installed.
 
 - plugins : stacheldraht : fixed a typo
 
-- plugins : added acc.nasl, netscape_wp_bug.nasl 
+- plugins : added acc.nasl, netscape_wp_bug.nasl
 
 - added nasl_version() and nessuslib_version(), as suggested
   by Scott Adkins <sadkins@voyager2.cns.ohiou.edu>
@@ -3634,10 +3634,10 @@ pkg-config is installed.
 
 - several new plugins
 
-- 'nasl' is a standalone NASL interpretor that can be used to debug 
+- 'nasl' is a standalone NASL interpreter that can be used to debug
   Nessus scripts and/or write independants ones.
 
-- the nasl guide has been updated and comes with libnasl/  
+- the nasl guide has been updated and comes with libnasl/
 
 0.99.7 :
 
@@ -3658,7 +3658,7 @@ pkg-config is installed.
 
 - New HTML export with pies and graphs
 
-- Handles the HTTP redirects (thanks to  
+- Handles the HTTP redirects (thanks to
   Andreas J. Koenig <andreas.koenig@anima.de> for requesting it)
 
 - behaves well when the same service is detected more than once on the target
@@ -3671,18 +3671,18 @@ pkg-config is installed.
   cleaner way
 - Corrected a bug in the client that would prevent it to work
   when not compiled with the cipher layer
-  
+
 - Added a inetd friendly option
 
-- The quiet mode of the client will produce HTML, LaTeX, text or 
+- The quiet mode of the client will produce HTML, LaTeX, text or
   .nsr files regarding the file suffix given as argument
-  
+
 - ASCII text output
 
 - report can be saved to stdout
 
 - kept-alive connection between the client and the server (no need to
-  log in again between two tests)  
+  log in again between two tests)
 
 0.99.4 :
 
@@ -3731,12 +3731,12 @@ Previous versions :
 - Man pages for nasl-config, nessus-config, nessus-build, as well
   as patches to problems that may occur during the installation
   by Josip Rodin <joy@cibalia.gkvk.hr>
-  
-- More efficient way to determine whether a DoS was successful or not.  
+
+- More efficient way to determine whether a DoS was successful or not.
   Thanks to Michel Arboi <arboi@alussinan.org> for the suggestion
   (does not work well yet)
 
 - The communication errors : 'out of threads already' and 'no cookie
   for received packets' have been fixed.
 
-- All the newest security tests  
+- All the newest security tests


### PR DESCRIPTION
While the CHANGELOG-OLD hasn't any relevance anymore still fix the existing typos so they are not showing up when searching for new ones in the repo via codespell