### PR TITLE
Fix revelead warning by gcc 8.3.

### DIFF
--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -58,7 +58,7 @@ const char *oid;
 static void
 register_service (struct script_infos *desc, int port, const char *proto)
 {
-  char k[96];
+  char k[265];
 
   /* Old "magical" key set */
   snprintf (k, sizeof (k), "Services/%s", proto);


### PR DESCRIPTION
register_service() accept strings up to 96 char for the key name,
but mark_socks_proxy() requieres 265 chars, and it can be truncated.