### PR TITLE
Wait for zombie process in case of timed out nvts.

### DIFF
--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -94,6 +94,7 @@ update_running_processes (kb_t kb)
       if (processes[i].pid > 0)
         {
           int is_alive = process_alive (processes[i].pid);
+          int ret_terminate = 0;
 
           // If process dead or timed out
           if (!is_alive
@@ -116,6 +117,15 @@ update_running_processes (kb_t kb)
                            "NVT timed out after %d seconds.",
                            oid ?: " ", processes[i].timeout);
                   kb_item_push_str (kb, "internal/results", msg);
+
+                  ret_terminate = terminate_process(processes[i].pid);
+                  if (ret_terminate == 0)
+                    {
+                      terminate_process (processes[i].pid * -1);
+                      num_running_processes--;
+                      processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
+                      bzero (&(processes[i]), sizeof (processes[i]));
+                    }
                 }
               else
                 {
@@ -143,11 +153,12 @@ update_running_processes (kb_t kb)
                       e = waitpid (processes[i].pid, NULL, 0);
                     }
                   while (e < 0 && errno == EINTR);
+
+                  terminate_process (processes[i].pid * -1);
+                  num_running_processes--;
+                  processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
+                  bzero (&(processes[i]), sizeof (processes[i]));
                 }
-              terminate_process (processes[i].pid * -1);
-              num_running_processes--;
-              processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
-              bzero (&(processes[i]), sizeof (processes[i]));
             }
         }
     }

--- a/src/processes.c
+++ b/src/processes.c
@@ -56,10 +56,15 @@ terminate_process (pid_t pid)
   if (ret == 0)
     {
       usleep (1000);
+
       if (waitpid (pid, NULL, WNOHANG) >= 0)
-        kill (pid, SIGKILL);
+        {
+          kill (pid, SIGKILL);
+          return -1;
+        }
     }
-  return -1;
+
+  return 0;
 }
 
 static void


### PR DESCRIPTION
Before, if an NVT timedout, the process is terminated and removed
from the running process struct, and the parent process does not wait for the child.
This leaved a zombie process until the end of the scan. The zombies proc become orphan proc
and removed for the system.
Now the timed out nvts are terminated, but a check is performerd to know
if the process was waited, before removing it from the running process struct.
In case it was not cleaned, it is kept in the running process table until is waited
for the parent and finally removed from the struct.