### PR TITLE
Reset redis connection after the host scan finished.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a type mismatch. Use correct format specifier for size_t. [#299](https://github.com/greenbone/openvas/pull/299)
 - An issue which caused falling back into a default port in get_ssh_port() has been fixed. [#342](https://github.com/greenbone/openvas/pull/342)
 - An issue which could have caused a truncated string in register_service() has been fixed. [#373](https://github.com/greenbone/openvas/pull/373)
+- Reset redis connection after the host scan finished. This avoids to leave open fd, which cause ulimit problems.[#384](https://github.com/greenbone/openvas/pull/384)
 
 ### Removed
 - Unused be_nice scan preferences has been removed. [#313](https://github.com/greenbone/openvas/pull/313)

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -94,6 +94,7 @@ host_rm (struct host *h)
   if (h->prev != NULL)
     h->prev->next = h->next;
 
+  kb_lnk_reset (h->host_kb);
   g_free (h->name);
   g_free (h->ip);
   g_free (h);


### PR DESCRIPTION
This avoids to leave open fd, which cause ulimit problems.
