### PR TITLE
Add directly single tags to nvti.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The greenbone-nvt-sync script is not allowed to run as root. [#323](https://github.com/greenbone/openvas/pull/323)
 - OpenVAS Scanner has been renamed to OpenVAS (Open Vulnerability Assessment Scanner). [#337](https://github.com/greenbone/openvas/pull/337) [#343](https://github.com/greenbone/openvas/pull/343)
 - Retry until a host finishes and frees a db before running a new host scan, in case there is no free redis db. Therefore a infinite loop has been added when it call kb_new(). [#340](https://github.com/greenbone/openvas/pull/340)
+- Use new nvti_add_tag() instead of plug_set_tag() and remove plug_set_tag(). [#385](https://github.com/greenbone/openvas/pull/385)
 
 ### Fixed
 - An issue with stuck scans where only a single plugin is running and is beyond its timeout has been addressed. [#289](https://github.com/greenbone/openvas/pull/289)

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -62,21 +62,6 @@ plug_current_vhost (void)
 static int plug_fork_child (kb_t);
 
 void
-plug_set_tag (struct script_infos *args, char *name, char *value)
-{
-  nvti_t *n = args->nvti;
-  char *new;
-
-  if (nvti_tag (n))
-    new = g_strconcat (nvti_tag (n), "|", name, "=", value, NULL);
-  else
-    new = g_strconcat (name, "=", value, NULL);
-
-  nvti_set_tag (n, new);
-  g_free (new);
-}
-
-void
 plug_set_dep (struct script_infos *args, const char *depname)
 {
   nvti_t *n = args->nvti;

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -44,9 +44,6 @@ void
 plug_set_dep (struct script_infos *, const char *);
 
 void
-plug_set_tag (struct script_infos *, char *, char *);
-
-void
 plug_set_ssl_cert (struct script_infos *, char *);
 
 void

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -241,7 +241,7 @@ script_tag (lex_ctxt *lexic)
       nasl_perror (lexic, "%s tag contains | separator", name);
       return FAKE_CELL;
     }
-  plug_set_tag (script_infos, name, value);
+  nvti_add_tag (script_infos->nvti, name, value);
 
   return FAKE_CELL;
 }


### PR DESCRIPTION
This removes knowledge about internal representation of tag sequence from openvas.
It should be the job of the nvti module to handle it on its own.

This requires https://github.com/greenbone/gvm-libs/pull/263