### PR TITLE
Fix detection of finger service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reset redis connection after the host scan finished. This avoids to leave open fd, which cause ulimit problems.[#384](https://github.com/greenbone/openvas/pull/384)
 - Fix mis-identification of Sphinx Search service. [#387](https://github.com/greenbone/openvas/pull/387)
 - Set a key in redis when the scan finishes and fix stop scan using the right pid.[#390](https://github.com/greenbone/openvas/pull/390)
+- Fix detection of finger service.[#391](https://github.com/greenbone/openvas/pull/391)
 
 ### Removed
 - Unused be_nice scan preferences has been removed. [#313](https://github.com/greenbone/openvas/pull/313)

--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -2201,12 +2201,7 @@ plugin_do_run (struct script_infos *desc, GSList *h, int test_ssl)
                                  != NULL
                             && strstr ((char *) banner,
                                        "finger: HTTP/1.0: no such user")
-                                 != NULL)
-                           || strstr ((char *) banner,
-                                      "Login       Name               TTY      "
-                                      "   Idle    When    Where")
-                           || strstr ((char *) banner, "Line     User")
-                           || strstr ((char *) banner, "Login name: GET"))
+                                 != NULL))
                     {
                       char c = '\0';
                       if (p != NULL)


### PR DESCRIPTION
This part of the code detected the service but never set the service as expected.
Therefore it was neither set the Service/unknown.
The code is removed and the service will be detected by code in a nasl script.
