### PR TITLE
Fix handling of file type nvt preferences. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set a key in redis when the scan finishes and fix stop scan using the right pid. [#390](https://github.com/greenbone/openvas/pull/390)
 - Fix detection of finger service. [#391](https://github.com/greenbone/openvas/pull/391)
 - Wait for zombie process in case of timed out nvts. [#379](https://github.com/greenbone/openvas/pull/379)
+- Fix handling of file type nvt preferences. [#399](https://github.com/greenbone/openvas/pull/399)
 
 ### Removed
 - Unused be_nice scan preferences has been removed. [#313](https://github.com/greenbone/openvas/pull/313)

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -39,6 +39,7 @@
 #include "pluginlaunch.h"          /* for init_loading_shm */
 #include "processes.h"             /* for create_process */
 #include "sighand.h"               /* for openvas_signal */
+#include "utils.h"                 /* for store_file */
 
 #include <errno.h>  /* for errno() */
 #include <fcntl.h>  /* for open() */
@@ -250,8 +251,14 @@ load_scan_preferences (struct scan_globals *globals)
               !strncmp (pref_name[2], "file", 4))
             {
               char *file_hash = gvm_uuid_make ();
+              int ret;
               prefs_set (pref[0], file_hash);
-              store_file (globals, pref[1], file_hash);
+              ret = store_file (globals, pref[1], file_hash);
+              if (ret)
+                g_debug ("Load preference: Failed to upload file "
+                         "for nvt %s preference.", pref_name[0]);
+
+              g_free(file_hash);
             }
           else
             prefs_set (pref[0], pref[1] ?: "");

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -244,7 +244,20 @@ load_scan_preferences (struct scan_globals *globals)
     {
       gchar **pref = g_strsplit (res->v_str, "|||", 2);
       if (pref[0])
-        prefs_set (pref[0], pref[1] ?: "");
+        {
+          gchar **pref_name = g_strsplit (pref[0], ":", 3);
+          if (pref_name[1] && pref_name[2] &&
+              !strncmp (pref_name[2], "file", 4))
+            {
+              char *file_hash = gvm_uuid_make ();
+              prefs_set (pref[0], file_hash);
+              store_file (globals, pref[1], file_hash);
+            }
+          else
+            prefs_set (pref[0], pref[1] ?: "");
+          g_strfreev (pref_name);
+        }
+
       g_strfreev (pref);
       res = res->next;
     }

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -247,8 +247,8 @@ load_scan_preferences (struct scan_globals *globals)
       if (pref[0])
         {
           gchar **pref_name = g_strsplit (pref[0], ":", 3);
-          if (pref_name[1] && pref_name[2] &&
-              !strncmp (pref_name[2], "file", 4))
+          if (pref_name[1] && pref_name[2]
+              && !strncmp (pref_name[2], "file", 4))
             {
               char *file_hash = gvm_uuid_make ();
               int ret;
@@ -256,9 +256,10 @@ load_scan_preferences (struct scan_globals *globals)
               ret = store_file (globals, pref[1], file_hash);
               if (ret)
                 g_debug ("Load preference: Failed to upload file "
-                         "for nvt %s preference.", pref_name[0]);
+                         "for nvt %s preference.",
+                         pref_name[0]);
 
-              g_free(file_hash);
+              g_free (file_hash);
             }
           else
             prefs_set (pref[0], pref[1] ?: "");

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -221,17 +221,17 @@ reload_openvas ()
  *         the kb.
  */
 static int
-load_scan_preferences (const char *scan_id)
+load_scan_preferences (struct scan_globals *globals)
 {
   char key[1024];
   kb_t kb;
   struct kb_item *res = NULL;
 
   g_debug ("Start loading scan preferences.");
-  if (!scan_id)
+  if (!globals->scan_id)
     return -1;
 
-  snprintf (key, sizeof (key), "internal/%s/scanprefs", scan_id);
+  snprintf (key, sizeof (key), "internal/%s/scanprefs", globals->scan_id);
   kb = kb_find (prefs_get ("db_address"), key);
   if (!kb)
     return -1;
@@ -248,7 +248,7 @@ load_scan_preferences (const char *scan_id)
       g_strfreev (pref);
       res = res->next;
     }
-  snprintf (key, sizeof (key), "internal/%s", scan_id);
+  snprintf (key, sizeof (key), "internal/%s", globals->scan_id);
   kb_item_set_str (kb, key, "ready", 0);
   kb_item_set_int (kb, "internal/ovas_pid", getpid ());
 
@@ -264,7 +264,7 @@ handle_client (struct scan_globals *globals)
   kb_t net_kb = NULL;
 
   /* Load preferences from Redis. Scan started with a scan_id. */
-  if (load_scan_preferences (globals->scan_id))
+  if (load_scan_preferences (globals))
     {
       g_warning ("No preferences found for the scan %s", globals->scan_id);
       exit (0);

--- a/src/utils.c
+++ b/src/utils.c
@@ -23,12 +23,14 @@
  * @brief A bunch of miscellaneous functions, mostly file conversions.
  */
 
-#include <errno.h>          /* for errno() */
-#include <gvm/base/prefs.h> /* for prefs_get() */
-#include <stdlib.h>         /* for atoi() */
-#include <string.h>         /* for strcmp() */
-#include <sys/ioctl.h>      /* for ioctl() */
-#include <sys/wait.h>       /* for waitpid() */
+#include "../misc/scanneraux.h" /* for struct scan_globals */
+
+#include <errno.h>             /* for errno() */
+#include <gvm/base/prefs.h>    /* for prefs_get() */
+#include <stdlib.h>            /* for atoi() */
+#include <string.h>            /* for strcmp() */
+#include <sys/ioctl.h>         /* for ioctl() */
+#include <sys/wait.h>          /* for waitpid() */
 
 extern int global_max_hosts;
 extern int global_max_checks;
@@ -38,6 +40,98 @@ extern int global_max_checks;
  * @brief GLib log domain.
  */
 #define G_LOG_DOMAIN "sd   main"
+
+
+/**
+ * @brief Adds a 'translation' entry for a file sent by the client.
+ *
+ * Files sent by the client are stored in memory on the server side.
+ * In order to access these files, their original name ('local' to the client)
+ * can be 'translated' into the file contents of the in-memory copy of the
+ * file on the server side.
+ *
+ * @param globals    Global struct.
+ * @param file_hash  hash to reference the file.
+ * @param contents   Contents of the file.
+ */
+static void
+files_add_translation (struct scan_globals *globals,
+                       const char *file_hash, char *contents)
+{
+  GHashTable *trans = globals->files_translation;
+  // Register the mapping table if none there yet
+  if (trans == NULL)
+    {
+      trans = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+      globals->files_translation = trans;
+    }
+
+  g_hash_table_insert (trans, g_strdup (file_hash), contents);
+}
+
+/**
+ * @brief Adds a 'content size' entry for a file sent by the client.
+ *
+ * Files sent by the client are stored in memory on the server side.
+ * Because they may be binary we need to store the size of the uploaded file as
+ * well. This function sets up a mapping from the original name sent by the
+ * client to the file size.
+ *
+ * @param globals    Global struct.
+ * @param file_hash  hash to reference the file.
+ * @param filesize   Size of the file in bytes.
+ */
+static void
+files_add_size_translation (struct scan_globals *globals,
+                            const char *file_hash, const long filesize)
+{
+  GHashTable *trans = globals->files_size_translation;
+  gchar *filesize_str = g_strdup_printf ("%ld", filesize);
+
+  // Register the mapping table if none there yet
+  if (trans == NULL)
+    {
+      trans = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+      globals->files_size_translation = trans;
+    }
+
+  g_hash_table_insert (trans, g_strdup (file_hash), g_strdup (filesize_str));
+}
+
+/**
+ * @brief Stores a file type preference.
+ *
+ * @return 0 if successful, -1 in case of errors.
+ */
+int
+store_file (struct scan_globals *globals, const char *file,
+            const char *file_hash)
+{
+  char *origname;
+  gchar *contents = NULL;
+
+  size_t bytes = 0;
+
+  if (!file_hash && *file_hash == '\0')
+    return -1;
+
+  origname = g_strdup (file_hash);
+
+  contents = (gchar *) g_base64_decode (file, &bytes);
+
+  if (contents == NULL)
+    {
+      g_debug ("store_file: Failed to allocate memory for uploaded file.");
+      g_free (origname);
+      return -1;
+    }
+
+  files_add_translation (globals, origname, contents);
+  files_add_size_translation (globals, origname, bytes);
+
+  g_free (origname);
+  return 0;
+}
 
 /**
  * Get the max number of hosts to test at the same time.

--- a/src/utils.c
+++ b/src/utils.c
@@ -25,12 +25,12 @@
 
 #include "../misc/scanneraux.h" /* for struct scan_globals */
 
-#include <errno.h>             /* for errno() */
-#include <gvm/base/prefs.h>    /* for prefs_get() */
-#include <stdlib.h>            /* for atoi() */
-#include <string.h>            /* for strcmp() */
-#include <sys/ioctl.h>         /* for ioctl() */
-#include <sys/wait.h>          /* for waitpid() */
+#include <errno.h>          /* for errno() */
+#include <gvm/base/prefs.h> /* for prefs_get() */
+#include <stdlib.h>         /* for atoi() */
+#include <string.h>         /* for strcmp() */
+#include <sys/ioctl.h>      /* for ioctl() */
+#include <sys/wait.h>       /* for waitpid() */
 
 extern int global_max_hosts;
 extern int global_max_checks;
@@ -40,7 +40,6 @@ extern int global_max_checks;
  * @brief GLib log domain.
  */
 #define G_LOG_DOMAIN "sd   main"
-
 
 /**
  * @brief Adds a 'translation' entry for a file sent by the client.
@@ -55,8 +54,8 @@ extern int global_max_checks;
  * @param contents   Contents of the file.
  */
 static void
-files_add_translation (struct scan_globals *globals,
-                       const char *file_hash, char *contents)
+files_add_translation (struct scan_globals *globals, const char *file_hash,
+                       char *contents)
 {
   GHashTable *trans = globals->files_translation;
   // Register the mapping table if none there yet
@@ -82,8 +81,8 @@ files_add_translation (struct scan_globals *globals,
  * @param filesize   Size of the file in bytes.
  */
 static void
-files_add_size_translation (struct scan_globals *globals,
-                            const char *file_hash, const long filesize)
+files_add_size_translation (struct scan_globals *globals, const char *file_hash,
+                            const long filesize)
 {
   GHashTable *trans = globals->files_size_translation;
   gchar *filesize_str = g_strdup_printf ("%ld", filesize);
@@ -99,7 +98,11 @@ files_add_size_translation (struct scan_globals *globals,
 }
 
 /**
- * @brief Stores a file type preference.
+ * @brief Stores a file type preference in a hash table.
+ *
+ * @param globals    Global struct.
+ * @param file       File content.
+ * @param file_hash  hash to reference the file.
  *
  * @return 0 if successful, -1 in case of errors.
  */

--- a/src/utils.h
+++ b/src/utils.h
@@ -45,4 +45,7 @@ wait_for_children1 (void);
 int
 is_scanner_only_pref (const char *);
 
+int
+store_file (struct scan_globals *, const char *, const char *);
+
 #endif


### PR DESCRIPTION
File type preference handling was removed when OTP was removed with PR #337

When the scanner loads the preferences, it will check if a given preference is "file" type. In this case the file is taken from redis encoded in base64, it will be decoded and stored as it was originally in previous versions.