### PR TITLE
[7.0] Improve handling of invalid or existent ids of nvt's preference id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [7.0.1] (unreleased)
 
+### Changed
+- Improve handling of invalid or existent ids of nvt's preference id. [#416](https://github.com/greenbone/openvas/pull/416)
+
 ### Fixed
 - Do not store in memory an empty file received as nvt preference. [#409](https://github.com/greenbone/openvas/pull/409)
 - Fix stop scan. [#414](https://github.com/greenbone/openvas/pull/414)

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -458,8 +458,15 @@ script_add_preference (lex_ctxt *lexic)
 
   if (!script_infos->nvti)
     return FAKE_CELL;
-  if (id <= 0)
+  if (id < 0)
     id = nvti_pref_len (script_infos->nvti) + 1;
+  if (id == 0)
+    {
+      nasl_perror (lexic,
+                   "Invalid id or not allowed id value in the call to %s()\n",
+                   __func__);
+      return FAKE_CELL;
+    }
   if (!name || !type || !value)
     {
       nasl_perror (lexic,
@@ -471,6 +478,11 @@ script_add_preference (lex_ctxt *lexic)
       if (!strcmp (name, nvtpref_name (nvti_pref (script_infos->nvti, i))))
         {
           nasl_perror (lexic, "Preference '%s' already exists\n", name);
+          return FAKE_CELL;
+        }
+      if (id == nvtpref_id (nvti_pref (script_infos->nvti, i)))
+        {
+          nasl_perror (lexic, "Invalid or already existent preferences id\n");
           return FAKE_CELL;
         }
     }

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -482,7 +482,7 @@ script_add_preference (lex_ctxt *lexic)
         }
       if (id == nvtpref_id (nvti_pref (script_infos->nvti, i)))
         {
-          nasl_perror (lexic, "Invalid or already existent preferences id\n");
+          nasl_perror (lexic, "Invalid or already existent preference id\n");
           return FAKE_CELL;
         }
     }


### PR DESCRIPTION
It detects if the id is repeted.
Also detects if the id 0 is beeing used, which is invalid because id 0 is reserved
for the timeout preferences. Also detects if an id has a non-integer value.