### PR TITLE
[7.0] fix hanging scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Do not store in memory an empty file received as nvt preference. [#409](https://github.com/greenbone/openvas/pull/409)
 - Fix stop scan. [#414](https://github.com/greenbone/openvas/pull/414)
+- Fix hanging scans. [#423](https://github.com/greenbone/openvas/pull/423)
 
 [7.0.1]: https://github.com/greenbone/openvas/compare/v7.0.0...openvas-7.0
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -1186,7 +1186,6 @@ attack_network (struct scan_globals *globals, kb_t *network_kb)
   while (hosts_read () == 0)
     ;
   g_message ("Test complete");
-  set_scan_status ("finished");
 
 scan_stop:
   /* Free the memory used by the files uploaded by the user, if any. */
@@ -1208,4 +1207,6 @@ stop:
 
   if (do_network_scan && network_phase && !scan_is_stopped ())
     attack_network (globals, network_kb);
+  else
+    set_scan_status ("finished");
 }


### PR DESCRIPTION
The finish of a scan did not get propagated correctly. This resulted in an indefinetely hanging progress bar.