### PR TITLE
Wait for all children instead of waiting just for one at time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Improve signal handling when update vhosts list. [#425](https://github.com/greenbone/openvas/pull/425)
+- Wait for all children instead of waiting just for one a time. [#428](https://github.com/greenbone/openvas/pull/428)
 
 [Unreleased]: https://github.com/greenbone/openvas/compare/openvas-7.0...master
 

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -226,8 +226,14 @@ static void
 hosts_read_data (void)
 {
   struct host *h = hosts;
+  int ret = 1;
 
-  waitpid (-1, NULL, WNOHANG);
+  while (ret > 0)
+    {
+      ret = waitpid (-1, NULL, WNOHANG);
+      if (ret < 0)
+        g_debug ("waitpid() failed. %s)", strerror (errno));
+    }
 
   if (h == NULL)
     return;


### PR DESCRIPTION
Clean all host zombie processes at once. It improves the scan duration
for scans with large targets with many dead hosts. Each zombie process
was waited for the parent one at time, which can produce a host process
table filled with finished hosts waiting for being released by the parent.