### PR TITLE
Add gvm libs version to openvas --version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [7.0.1] (unreleased)
 
+### Added
+- Display gvm-libs version in `openvas --version` output [#436](https://github.com/greenbone/openvas/pull/436)
+
 ### Changed
 - Improve handling of invalid or existent ids of nvt's preference id. [#416](https://github.com/greenbone/openvas/pull/416)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT PKG_CONFIG_FOUND)
   message(FATAL_ERROR "pkg-config executable not found. Aborting.")
 endif (NOT PKG_CONFIG_FOUND)
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=11.0.0)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=11.0.1)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=11.0.0)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -50,6 +50,7 @@
 #include <gvm/base/nvti.h>      /* for prefs_get() */
 #include <gvm/base/prefs.h>     /* for prefs_get() */
 #include <gvm/base/proctitle.h> /* for proctitle_set */
+#include <gvm/base/version.h>   /* for gvm_libs_version */
 #include <gvm/util/kb.h>        /* for KB_PATH_DEFAULT */
 #include <gvm/util/nvticache.h> /* nvticache_free */
 #include <gvm/util/uuidutils.h> /* gvm_uuid_make */
@@ -485,6 +486,7 @@ openvas (int argc, char *argv[])
 #ifdef OPENVAS_GIT_REVISION
       printf ("GIT revision %s\n", OPENVAS_GIT_REVISION);
 #endif
+      printf ("gvm-libs %s\n", gvm_libs_version ());
       printf ("Most new code since 2005: (C) 2019 Greenbone Networks GmbH\n");
       printf (
         "Nessus origin: (C) 2004 Renaud Deraison <deraison@nessus.org>\n");


### PR DESCRIPTION
Print gvm libs version in openvas --version output.

Requires https://github.com/greenbone/gvm-libs/pull/301