### PR TITLE
Create a lock file for sync the feed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Display gvm-libs version in `openvas --version` output [#436](https://github.com/greenbone/openvas/pull/436)
+- Create greenbone-nvt-sync create lock file during feed sync. [#457](https://github.com/greenbone/openvas/pull/457)
 
 ### Changed
 - Improve handling of invalid or existent ids of nvt's preference id. [#416](https://github.com/greenbone/openvas/pull/416)
 - Perform a scan even if there are missing plugins. [#439](https://github.com/greenbone/openvas/pull/439)
+- Don't reload the plugins when start a new scan. [#457](https://github.com/greenbone/openvas/pull/457)
 
 ### Fixed
 - Do not store in memory an empty file received as nvt preference. [#409](https://github.com/greenbone/openvas/pull/409)

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -368,7 +368,6 @@ void
 start_single_task_scan ()
 {
   struct scan_globals *globals;
-  int ret = 0;
 
 #if GNUTLS_VERSION_NUMBER < 0x030300
   if (openvas_SSL_init () < 0)
@@ -382,10 +381,6 @@ start_single_task_scan ()
   g_message ("openvas %s started", OPENVAS_VERSION);
 #endif
 
-  openvas_signal (SIGHUP, SIG_IGN);
-  ret = plugins_init ();
-  if (ret)
-    exit (0);
   init_signal_handlers ();
 
   globals = g_malloc0 (sizeof (struct scan_globals));

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -638,7 +638,7 @@ do_feedversion () {
 create_feed_lock_file ()
 {
   if [ -f $OPENVAS_RUN_DIR/feed-update.lock ] ; then
-    stderr_write "Another process related to the feed update is already running"
+    log_warning "Another process related to the feed update is already running."
     FEED_LOCKED=1
   else
     touch $OPENVAS_RUN_DIR/feed-update.lock

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -71,6 +71,9 @@ PORT=24
 # Directory where the OpenVAS Scanner configuration is located
 OPENVAS_SYSCONF_DIR="@OPENVAS_SYSCONF_DIR@"
 
+# Directory where the feed update lock file will be placed.
+OPENVAS_RUN_DIR="@OPENVAS_RUN_DIR@"
+
 # Location of the GSF Access Key
 ACCESS_KEY="@GVM_ACCESS_KEY_DIR@/gsf-access-key"
 
@@ -632,6 +635,17 @@ do_feedversion () {
   fi
 }
 
+create_feed_lock_file ()
+{
+  if [ -f $OPENVAS_RUN_DIR/feed-update.lock ] ; then
+    stderr_write "Another process related to the feed update is already running"
+    FEED_LOCKED=1
+  else
+    touch $OPENVAS_RUN_DIR/feed-update.lock
+    FEED_LOCKED=0
+  fi
+}
+
 do_sync ()
 {
   do_self_test
@@ -643,7 +657,13 @@ do_sync ()
   then
     log_write "Feed is already current, skipping synchronization."
   else
+    create_feed_lock_file
+    if [ $FEED_LOCKED -eq 1 ] ; then
+       exit 1
+    fi
+
     sync_nvts
+    rm $OPENVAS_RUN_DIR/feed-update.lock
   fi
 }
 


### PR DESCRIPTION
Also, do not reload plugins when start a scan. 