### PR TITLE
Do not reload plugins when start a scan.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Create greenbone-nvt-sync create lock file during feed sync. [#458](https://github.com/greenbone/openvas/pull/458)
+
 ### Changed
 - The logging of the NASL internal regexp functions was extended to include the pattern in case of a failed regcomp(). [#397](https://github.com/greenbone/openvas/pull/397)
 - Add config for gpg keyring path (OPENVAS_GPG_BASE_DIR) [#407](https://github.com/greenbone/openvas/pull/407)
 - Use __func__ instead of __FUNCTION__ [#419](https://github.com/greenbone/openvas/pull/419)
 - Use pcap_findalldevs() instead of deprecated function pcap_lookupdev() [#422](https://github.com/greenbone/openvas/pull/422) [#430](https://github.com/greenbone/openvas/pull/430)
 - Add port-range option for openvas-nasl [#431](https://github.com/greenbone/openvas/pull/431)
+- Don't reload the plugins when start a new scan. [#458](https://github.com/greenbone/openvas/pull/458)
 
 ### Fixed
 - Improve signal handling when update vhosts list. [#425](https://github.com/greenbone/openvas/pull/425)

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -368,7 +368,6 @@ void
 start_single_task_scan (void)
 {
   struct scan_globals *globals;
-  int ret = 0;
 
 #if GNUTLS_VERSION_NUMBER < 0x030300
   if (openvas_SSL_init () < 0)
@@ -382,10 +381,6 @@ start_single_task_scan (void)
   g_message ("openvas %s started", OPENVAS_VERSION);
 #endif
 
-  openvas_signal (SIGHUP, SIG_IGN);
-  ret = plugins_init ();
-  if (ret)
-    exit (0);
   init_signal_handlers ();
 
   globals = g_malloc0 (sizeof (struct scan_globals));

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -71,6 +71,9 @@ PORT=24
 # Directory where the OpenVAS configuration is located
 OPENVAS_SYSCONF_DIR="@OPENVAS_SYSCONF_DIR@"
 
+# Directory where the feed update lock file will be placed.
+OPENVAS_RUN_DIR="@OPENVAS_RUN_DIR@"
+
 # Location of the GSF Access Key
 ACCESS_KEY="@GVM_ACCESS_KEY_DIR@/gsf-access-key"
 
@@ -632,6 +635,17 @@ do_feedversion () {
   fi
 }
 
+create_feed_lock_file ()
+{
+  if [ -f $OPENVAS_RUN_DIR/feed-update.lock ] ; then
+    log_warning "Another process related to the feed update is already running"
+    FEED_LOCKED=1
+  else
+    touch $OPENVAS_RUN_DIR/feed-update.lock
+    FEED_LOCKED=0
+  fi
+}
+
 do_sync ()
 {
   do_self_test
@@ -643,7 +657,13 @@ do_sync ()
   then
     log_write "Feed is already current, skipping synchronization."
   else
+    create_feed_lock_file
+    if [ $FEED_LOCKED -eq 1 ] ; then
+       exit 1
+    fi
+
     sync_nvts
+    rm $OPENVAS_RUN_DIR/feed-update.lock
   fi
 }
 


### PR DESCRIPTION
Also, create a lock file during the feed sync.