### PR TITLE
[7] Fix init nvticache init.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Display gvm-libs version in `openvas --version` output [#436](https://github.com/greenbone/openvas/pull/436)
-- Create greenbone-nvt-sync create lock file during feed sync. [#457](https://github.com/greenbone/openvas/pull/457)
+- Create greenbone-nvt-sync create lock file during feed sync.
+  [#457](https://github.com/greenbone/openvas/pull/457)
+  [#460](https://github.com/greenbone/openvas/pull/460)
 
 ### Changed
 - Improve handling of invalid or existent ids of nvt's preference id. [#416](https://github.com/greenbone/openvas/pull/416)

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -381,6 +381,11 @@ start_single_task_scan ()
   g_message ("openvas %s started", OPENVAS_VERSION);
 #endif
 
+  if (plugins_cache_init ())
+    {
+      g_message ("Failed to initialize nvti cache.");
+      exit (1);
+    }
   init_signal_handlers ();
 
   globals = g_malloc0 (sizeof (struct scan_globals));

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -351,6 +351,23 @@ include_dirs (void)
       g_strfreev (include_folders);
     }
 }
+/**
+ * @brief Main function for nvticache initialization without
+ *        loading the plugins
+ **/
+int
+plugins_cache_init (void)
+{
+  const char *plugins_folder = prefs_get ("plugins_folder");
+
+  if (nvticache_init (plugins_folder, prefs_get ("db_address")))
+    {
+      g_debug ("Failed to initialize nvti cache.");
+      return -1;
+    }
+  include_dirs ();
+  return 0;
+}
 
 /*
  * main function for loading all the plugins
@@ -362,12 +379,9 @@ plugins_init (void)
   pid_t child_pid;
   const char *plugins_folder = prefs_get ("plugins_folder");
 
-  if (nvticache_init (plugins_folder, prefs_get ("db_address")))
-    {
-      g_debug ("Failed to initialize nvti cache.");
-      return -1;
-    }
-  include_dirs ();
+  ret = plugins_cache_init ();
+  if (ret)
+    return ret;
 
   child_pid = create_process (plugins_reload_from_dir, (void *) plugins_folder);
   waitpid (child_pid, &ret, 0);

--- a/src/pluginload.h
+++ b/src/pluginload.h
@@ -34,6 +34,9 @@
 int
 plugins_init (void);
 
+int
+plugins_cache_init (void);
+
 void
 init_loading_shm (void);
 


### PR DESCRIPTION
Add a new function to initialize the nvticache without loading the plugins.