### PR TITLE
Fix format-truncation warning in GCC 8.2 and later.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Create greenbone-nvt-sync create lock file during feed sync.
   [#458](https://github.com/greenbone/openvas/pull/458)
   [#459](https://github.com/greenbone/openvas/pull/459)
+- Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
 
 ### Changed
 - The logging of the NASL internal regexp functions was extended to include the pattern in case of a failed regcomp(). [#397](https://github.com/greenbone/openvas/pull/397)

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -96,9 +96,13 @@ epoch2isotime (my_isotime_t timebuf, time_t atime)
       struct tm *tp;
 
       tp = gmtime (&atime);
-      snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-                1900 + tp->tm_year, tp->tm_mon + 1, tp->tm_mday, tp->tm_hour,
-                tp->tm_min, tp->tm_sec);
+      if (snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+                    1900 + tp->tm_year, tp->tm_mon + 1, tp->tm_mday,
+                    tp->tm_hour, tp->tm_min, tp->tm_sec) < 0)
+        {
+          *timebuf = '\0';
+          return;
+        }
     }
 }
 
@@ -433,8 +437,10 @@ add_seconds_to_isotime (my_isotime_t atime, int nseconds)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month, day,
-            hour, minute, sec);
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+               year, month, day, hour, minute, sec) < 0)
+    return 1;
+
   return 0;
 }
 
@@ -469,8 +475,9 @@ add_days_to_isotime (my_isotime_t atime, int ndays)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month, day,
-            hour, minute, sec);
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+                year, month, day, hour, minute, sec) < 0)
+    return 1;
   return 0;
 }
 
@@ -505,8 +512,10 @@ add_years_to_isotime (my_isotime_t atime, int nyears)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month, day,
-            hour, minute, sec);
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+                year, month, day, hour, minute, sec) < 0)
+    return 1;
+
   return 0;
 }
 

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -98,7 +98,8 @@ epoch2isotime (my_isotime_t timebuf, time_t atime)
       tp = gmtime (&atime);
       if (snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
                     1900 + tp->tm_year, tp->tm_mon + 1, tp->tm_mday,
-                    tp->tm_hour, tp->tm_min, tp->tm_sec) < 0)
+                    tp->tm_hour, tp->tm_min, tp->tm_sec)
+          < 0)
         {
           *timebuf = '\0';
           return;
@@ -437,8 +438,9 @@ add_seconds_to_isotime (my_isotime_t atime, int nseconds)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-               year, month, day, hour, minute, sec) < 0)
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month,
+                day, hour, minute, sec)
+      < 0)
     return 1;
 
   return 0;
@@ -475,8 +477,9 @@ add_days_to_isotime (my_isotime_t atime, int ndays)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-                year, month, day, hour, minute, sec) < 0)
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month,
+                day, hour, minute, sec)
+      < 0)
     return 1;
   return 0;
 }
@@ -512,8 +515,9 @@ add_years_to_isotime (my_isotime_t atime, int nyears)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-                year, month, day, hour, minute, sec) < 0)
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month,
+                day, hour, minute, sec)
+      < 0)
     return 1;
 
   return 0;


### PR DESCRIPTION
Warning is erroneous, as the number of printed bytes is limited. Check
snprintf() return value to silence it.

This had been already fixed in the old openvas-libraries, but never backported to OpenVAS scanner.
Original patches from @kroosec are PR greenbone/gvm-libs#130 and greenbone/gvm-libs#148.