### PR TITLE
[7.0] Fix format-truncation warning in GCC 8.2 and later.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix hanging scans. [#423](https://github.com/greenbone/openvas/pull/423)
 - Improve signal handling when update vhosts list. [#426](https://github.com/greenbone/openvas/pull/426)
 - Wait for all children instead of waiting just for one a time. [#429](https://github.com/greenbone/openvas/pull/429)
+- Fix format-truncation warning in GCC 8.2 and later. [#462](https://github.com/greenbone/openvas/pull/462)
 
 [7.0.1]: https://github.com/greenbone/openvas/compare/v7.0.0...openvas-7.0
 

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -96,9 +96,13 @@ epoch2isotime (my_isotime_t timebuf, time_t atime)
       struct tm *tp;
 
       tp = gmtime (&atime);
-      snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-                1900 + tp->tm_year, tp->tm_mon + 1, tp->tm_mday, tp->tm_hour,
-                tp->tm_min, tp->tm_sec);
+      if (snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+                    1900 + tp->tm_year, tp->tm_mon + 1, tp->tm_mday,
+                    tp->tm_hour, tp->tm_min, tp->tm_sec) < 0)
+        {
+          *timebuf = '\0';
+          return;
+        }
     }
 }
 
@@ -433,8 +437,10 @@ add_seconds_to_isotime (my_isotime_t atime, int nseconds)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month, day,
-            hour, minute, sec);
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+               year, month, day, hour, minute, sec) < 0)
+    return 1;
+
   return 0;
 }
 
@@ -469,8 +475,9 @@ add_days_to_isotime (my_isotime_t atime, int ndays)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month, day,
-            hour, minute, sec);
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+                year, month, day, hour, minute, sec) < 0)
+    return 1;
   return 0;
 }
 
@@ -505,8 +512,10 @@ add_years_to_isotime (my_isotime_t atime, int nyears)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month, day,
-            hour, minute, sec);
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+                year, month, day, hour, minute, sec) < 0)
+    return 1;
+
   return 0;
 }
 

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -98,7 +98,8 @@ epoch2isotime (my_isotime_t timebuf, time_t atime)
       tp = gmtime (&atime);
       if (snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
                     1900 + tp->tm_year, tp->tm_mon + 1, tp->tm_mday,
-                    tp->tm_hour, tp->tm_min, tp->tm_sec) < 0)
+                    tp->tm_hour, tp->tm_min, tp->tm_sec)
+          < 0)
         {
           *timebuf = '\0';
           return;
@@ -437,8 +438,9 @@ add_seconds_to_isotime (my_isotime_t atime, int nseconds)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-               year, month, day, hour, minute, sec) < 0)
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month,
+                day, hour, minute, sec)
+      < 0)
     return 1;
 
   return 0;
@@ -475,8 +477,9 @@ add_days_to_isotime (my_isotime_t atime, int ndays)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-                year, month, day, hour, minute, sec) < 0)
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month,
+                day, hour, minute, sec)
+      < 0)
     return 1;
   return 0;
 }
@@ -512,8 +515,9 @@ add_years_to_isotime (my_isotime_t atime, int nyears)
   if (year > 9999 || month > 12 || day > 31 || year < 0 || month < 1 || day < 1)
     return 1;
 
-  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
-                year, month, day, hour, minute, sec) < 0)
+  if (snprintf (atime, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d", year, month,
+                day, hour, minute, sec)
+      < 0)
     return 1;
 
   return 0;


### PR DESCRIPTION
Backport PR #461 