### PR TITLE
Re-add dropped environmental variable text in feed sync script with e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#459](https://github.com/greenbone/openvas/pull/459)
 - Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
 - Extend script_get_preference() to get the value by id. [#470](https://github.com/greenbone/openvas/pull/470)
+- Add extended environmental variables info to greenbone-nvt-sync help text. [#488](https://github.com/greenbone/openvas/pull/488)
 
 ### Changed
 - The logging of the NASL internal regexp functions was extended to include the pattern in case of a failed regcomp(). [#397](https://github.com/greenbone/openvas/pull/397)

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -540,6 +540,7 @@ do_help () {
   echo "NVT_DIR         where to extract plugins (absolute path)"
   echo "PRIVATE_SUBDIR  subdirectory of \$NVT_DIR to exclude from synchronization"
   echo "TMPDIR          temporary directory used to download the files"
+  echo "Note that you can use standard ones as well (e.g. RSYNC_PROXY) for rsync"
   echo ""
   exit 0
 }


### PR DESCRIPTION
…xtended info.

As suggested in https://github.com/greenbone/openvas/pull/478/files#r407238362. The info existed in the "old" openvas-nvt-sync script since longer time and should be included here as well:

https://github.com/greenbone/openvas/blob/openvas-scanner-5.0/doc/openvas-nvt-sync.8#L28