### PR TITLE
Drop HTTP sync (7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wait for all children instead of waiting just for one a time. [#429](https://github.com/greenbone/openvas/pull/429)
 - Fix format-truncation warning in GCC 8.2 and later. [#462](https://github.com/greenbone/openvas/pull/462)
 
+### Removed
+- Drop HTTP sync [#489](https://github.com/greenbone/openvas/pull/489)
+
 [7.0.1]: https://github.com/greenbone/openvas/compare/v7.0.0...openvas-7.0
 
 ## [7.0.0] (2019-10-11)

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -201,7 +201,6 @@ else
 fi
 
 RSYNC=`command -v rsync`
-WGET=`command -v wget`
 CURL=`command -v curl`
 
 if [ -z "$TMPDIR" ]; then
@@ -369,38 +368,6 @@ is_feed_current () {
   return $FEED_CURRENT
 }
 
-do_wget_community_feed () {
-  TMP_NVT="$SYNC_TMP_DIR/gcf-`date +%F`-$$.tar.bz2"
-
-  log_info "Configured NVT http feed: $COMMUNITY_NVT_HTTP_FEED"
-  log_info "Downloading to: $TMP_NVT"
-  mkdir -p "$NVT_DIR"
-
-  wget "$COMMUNITY_NVT_HTTP_FEED" -O $TMP_NVT
-
-  if [ $? -ne 0 ]
-  then
-    rm -f $TMP_NVT
-    log_err "wget failed"
-    exit 1
-  else
-    log_info "Download complete"
-  fi
-
-  cd "$NVT_DIR" \
-    && tar xvjf $TMP_NVT
-
-  if [ $? -ne 0 ]
-  then
-    rm -f $TMP_NVT
-    log_err "tar extraction failed."
-    exit 1
-  else
-    rm -f $TMP_NVT
-    log_info "NVTs extracted successfully"
-  fi
-}
-
 do_curl_community_feed () {
   TMP_NVT="$SYNC_TMP_DIR/gcf-`date +%F`-$$.tar.bz2"
 
@@ -462,14 +429,6 @@ do_sync_community_feed () {
       log_info "Will use rsync"
       do_rsync_community_feed
     fi
-  elif [ "wget" = "$FIXED_METHOD" ] ; then
-    if [ -z "$WGET" ] ; then
-      log_err "wget requested but not found! Aborting synchronization."
-      exit 1
-    else
-      log_info "Will use wget"
-      do_wget_community_feed
-    fi
   elif [ "curl" = "$FIXED_METHOD" ] ; then
     if [ -z "$CURL" ] ; then
       log_err "curl requested but not found! Aborting synchronization."
@@ -484,19 +443,13 @@ do_sync_community_feed () {
     else
       log_warning "rsync not found!"
     fi
-    if [ -z "$WGET" ]; then
-      log_warning "GNU wget not found!"
-      if [ -z "$CURL" ]; then
-        log_warning "curl not found!"
-        log_err "no utility available in PATH environment variable to download plugins"
-        exit 1
-      else
-        log_info "Will use curl"
-        do_curl_community_feed
-      fi
+    if [ -z "$CURL" ]; then
+      log_warning "curl not found!"
+      log_err "no utility available in PATH environment variable to download plugins"
+      exit 1
     else
-      log_info "Will use wget"
-      do_wget_community_feed
+      log_info "Will use curl"
+      do_curl_community_feed
     fi
   else
     log_info "Will use rsync"
@@ -680,14 +633,13 @@ do_help () {
   echo " --selftest     perform self-test"
   echo " --verbose      makes the sync process print details"
   echo " --version      display version"
-  echo " --wget         only use wget to download feed files"
   echo ""
   echo ""
   echo "Environment variables:"
   echo "NVT_DIR         where to extract plugins (absolute path)"
   echo "PRIVATE_SUBDIR  subdirectory of \$NVT_DIR to exclude from synchronization"
   echo "TMPDIR          temporary directory used to download the files"
-  echo "Note that you can use standard ones as well (e.g. http_proxy) for wget/curl"
+  echo "Note that you can use standard ones as well (e.g. http_proxy) for curl"
   echo ""
   exit 0
 }
@@ -700,9 +652,6 @@ while test $# -gt 0; do
       ;;
     --rsync)
       FIXED_METHOD="rsync"
-      ;;
-    --wget)
-      FIXED_METHOD="wget"
       ;;
     --curl)
       FIXED_METHOD="curl"

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -540,6 +540,7 @@ do_help () {
   echo "NVT_DIR         where to extract plugins (absolute path)"
   echo "PRIVATE_SUBDIR  subdirectory of \$NVT_DIR to exclude from synchronization"
   echo "TMPDIR          temporary directory used to download the files"
+  echo "Note that you can use standard ones as well (e.g. RSYNC_PROXY) for rsync"
   echo ""
   exit 0
 }

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -354,22 +354,17 @@ is_feed_current () {
 }
 
 do_rsync_community_feed () {
-  if [ -z "$RSYNC" ]; then
-    log_err "rsync not found!"
-  else
-    log_notice "Using rsync: $RSYNC"
-    log_notice "Configured NVT rsync feed: $COMMUNITY_NVT_RSYNC_FEED"
-    mkdir -p "$NVT_DIR"
-    eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED\" \"$NVT_DIR\" --exclude=plugin_feed_info.inc"
-    if [ $? -ne 0 ] ; then
-      log_err "rsync failed."
-      exit 1
-    fi
-    eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$NVT_DIR\""
-    if [ $? -ne 0 ] ; then
-      log_err "rsync failed."
-      exit 1
-    fi
+  log_notice "Configured NVT rsync feed: $COMMUNITY_NVT_RSYNC_FEED"
+  mkdir -p "$NVT_DIR"
+  eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED\" \"$NVT_DIR\" --exclude=plugin_feed_info.inc"
+  if [ $? -ne 0 ] ; then
+    log_err "rsync failed."
+    exit 1
+  fi
+  eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$NVT_DIR\""
+  if [ $? -ne 0 ] ; then
+    log_err "rsync failed."
+    exit 1
   fi
 }
 
@@ -536,7 +531,7 @@ do_help () {
   echo " --help         display this help"
   echo " --identify     display information"
   echo " --nvtdir dir   set dir as NVT directory"
-  echo " --selftest     perform self-test"
+  echo " --selftest     perform self-test and set exit code"
   echo " --verbose      makes the sync process print details"
   echo " --version      display version"
   echo ""

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -194,14 +194,9 @@ else
     # An alternative syntax which might work if the above doesn't:
     # COMMUNITY_NVT_RSYNC_FEED=rsync@feed.community.greenbone.net::/nvt-feed
   fi
-
-  if [ -z "$COMMUNITY_NVT_HTTP_FEED" ]; then
-    COMMUNITY_NVT_HTTP_FEED=http://dl.greenbone.net/community-nvt-feed-current.tar.bz2
-  fi
 fi
 
 RSYNC=`command -v rsync`
-CURL=`command -v curl`
 
 if [ -z "$TMPDIR" ]; then
   SYNC_TMP_DIR=/tmp
@@ -368,38 +363,6 @@ is_feed_current () {
   return $FEED_CURRENT
 }
 
-do_curl_community_feed () {
-  TMP_NVT="$SYNC_TMP_DIR/gcf-`date +%F`-$$.tar.bz2"
-
-  log_info "Configured NVT http feed: $COMMUNITY_NVT_HTTP_FEED"
-  log_info "Downloading to: $TMP_NVT"
-  mkdir -p "$NVT_DIR"
-
-  curl "$COMMUNITY_NVT_HTTP_FEED" -o $TMP_NVT
-
-  if [ $? -ne 0 ] || [ ! -f $TMP_NVT ]
-  then
-    rm -f $TMP_NVT
-    log_err "curl failed"
-    exit 1
-  else
-    log_info "Download complete"
-  fi
-
-  cd "$NVT_DIR" \
-    && tar xvjf $TMP_NVT
-
-  if [ $? -ne 0 ]
-  then
-    rm -f $TMP_NVT
-    log_err "tar extraction failed."
-    exit 1
-  else
-    rm -f $TMP_NVT
-    log_info "NVTs extracted successfully"
-  fi
-}
-
 do_rsync_community_feed () {
   if [ -z "$RSYNC" ]; then
     log_err "rsync not found!"
@@ -417,43 +380,6 @@ do_rsync_community_feed () {
       log_err "rsync failed."
       exit 1
     fi
-  fi
-}
-
-do_sync_community_feed () {
-  if [ "rsync" = "$FIXED_METHOD" ] ; then
-    if [ -z "$RSYNC" ] ; then
-      log_err "rsync requested but not found! Aborting synchronization."
-      exit 1
-    else
-      log_info "Will use rsync"
-      do_rsync_community_feed
-    fi
-  elif [ "curl" = "$FIXED_METHOD" ] ; then
-    if [ -z "$CURL" ] ; then
-      log_err "curl requested but not found! Aborting synchronization."
-      exit 1
-    else
-      log_info "Will use curl"
-      do_curl_community_feed
-    fi
-  elif [ -z "$RSYNC" ] || [ $FEED_PRESENT -eq 0 ] ; then
-    if [ $FEED_PRESENT -eq 0 ] ; then
-      log_notice "rsync is not recommended for the initial sync. Falling back on http."
-    else
-      log_warning "rsync not found!"
-    fi
-    if [ -z "$CURL" ]; then
-      log_warning "curl not found!"
-      log_err "no utility available in PATH environment variable to download plugins"
-      exit 1
-    else
-      log_info "Will use curl"
-      do_curl_community_feed
-    fi
-  else
-    log_info "Will use rsync"
-    do_rsync_community_feed
   fi
 }
 
@@ -552,7 +478,7 @@ sync_nvts(){
     fi
   else
     log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
-    do_sync_community_feed
+    do_rsync_community_feed
   fi
 }
 
@@ -622,7 +548,6 @@ do_sync ()
 
 do_help () {
   echo "$0: Sync NVT data"
-  echo " --curl         only use curl to download feed files"
   echo " --describe     display current feed info"
   echo " --feedcurrent  just check if feed is up-to-date"
   echo " --feedversion  display version of this feed"
@@ -639,7 +564,6 @@ do_help () {
   echo "NVT_DIR         where to extract plugins (absolute path)"
   echo "PRIVATE_SUBDIR  subdirectory of \$NVT_DIR to exclude from synchronization"
   echo "TMPDIR          temporary directory used to download the files"
-  echo "Note that you can use standard ones as well (e.g. http_proxy) for curl"
   echo ""
   exit 0
 }
@@ -652,9 +576,6 @@ while test $# -gt 0; do
       ;;
     --rsync)
       FIXED_METHOD="rsync"
-      ;;
-    --curl)
-      FIXED_METHOD="curl"
       ;;
     --identify)
       echo "NVTSYNC|$SCRIPT_NAME|$VERSION|$FEED_NAME|$RESTRICTED|NVTSYNC"
@@ -694,4 +615,3 @@ done
 do_sync
 
 exit 0
-

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -270,17 +270,19 @@ is_feed_current () {
     return $FEED_CURRENT
   fi
 
+  if [ -z "$RSYNC" ]
+  then
+    log_notice "rsync not available, skipping feed version test"
+    FEED_CURRENT=0
+    rm -rf $FEED_INFO_TEMP_DIR
+    cleanup_temp_access_key
+    return 0
+  fi
+
   FEED_INFO_TEMP_DIR=`mktemp -d`
 
   if [ -e $ACCESS_KEY ]
   then
-    if [ -n "$FIXED_METHOD" ] && [ "rsync" != "$FIXED_METHOD" ]
-    then
-      log_err "Sync with access key must be run with rsync. Aborting synchronization."
-      stderr_write "Sync with access key must be run with rsync."
-      exit 1
-    fi
-
     gsmproxy=$(get_value proxy_feed | sed -r -e 's/^.*\/\///' -e 's/:([0-9]+)$/ \1/')
     syncport=$(get_value syncport)
     if [ "$syncport" ]
@@ -318,8 +320,7 @@ is_feed_current () {
       rm -rf "$FEED_INFO_TEMP_DIR"
       exit 1
     fi
-  elif [ -n "$RSYNC" ] && [ -z "$FIXED_METHOD" -o "$FIXED_METHOD" = "rsync" ]
-  then
+  else
     log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     eval "$RSYNC -ltvrP \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$FEED_INFO_TEMP_DIR\""
     if [ $? -ne 0 ]
@@ -328,17 +329,6 @@ is_feed_current () {
       rm -rf "$FEED_INFO_TEMP_DIR"
       exit 1
     fi
-  else
-    if [ -n "$FIXED_METHOD" ]
-    then
-      log_notice "non-rsync method selected, skipping feed version test"
-    else
-      log_notice "rsync not available, skipping feed version test"
-    fi
-    FEED_CURRENT=0
-    rm -rf $FEED_INFO_TEMP_DIR
-    cleanup_temp_access_key
-    return 0
   fi
 
   FEED_VERSION_SERVER=`grep PLUGIN_SET $FEED_INFO_TEMP_DIR/plugin_feed_info.inc | sed -e 's/[^0-9]//g'`
@@ -392,13 +382,6 @@ sync_nvts(){
 
   if [ -e $ACCESS_KEY ]
   then
-    if [ -n "$FIXED_METHOD" ] && [ "rsync" != "$FIXED_METHOD" ]
-    then
-      log_err "Sync with access key must be run with rsync. Aborting synchronization."
-      stderr_write "Sync with access key must be run with rsync."
-      exit 1
-    fi
-
     log_write "Synchronizing NVTs from the Greenbone Security Feed into $NVT_DIR..."
     if [ $FEED_PRESENT -eq 1 ] ; then
       FEEDCOUNT=`grep -E "nasl$|inc$" $NVT_DIR/md5sums | wc -l`
@@ -489,12 +472,11 @@ do_self_test ()
     SELFTEST_FAIL=1
     stderr_write "The md5sum binary could not be found."
   fi
-  if [ -s $ACCESS_KEY ] ; then
-    RSYNC_AVAIL=`command -v rsync`
-    if [ $? -ne 0 ] ; then
-      SELFTEST_FAIL=1
-      stderr_write "The rsync binary could not be found."
-    fi
+
+  RSYNC_AVAIL=`command -v rsync`
+  if [ $? -ne 0 ] ; then
+    SELFTEST_FAIL=1
+    stderr_write "The rsync binary could not be found."
   fi
 }
 
@@ -554,7 +536,6 @@ do_help () {
   echo " --help         display this help"
   echo " --identify     display information"
   echo " --nvtdir dir   set dir as NVT directory"
-  echo " --rsync        only use rsync to download feed files"
   echo " --selftest     perform self-test"
   echo " --verbose      makes the sync process print details"
   echo " --version      display version"
@@ -573,9 +554,6 @@ while test $# -gt 0; do
     --version)
       echo $VERSION
       exit 0
-      ;;
-    --rsync)
-      FIXED_METHOD="rsync"
       ;;
     --identify)
       echo "NVTSYNC|$SCRIPT_NAME|$VERSION|$FEED_NAME|$RESTRICTED|NVTSYNC"


### PR DESCRIPTION
This removes wget and curl options for feed download.
These methods always download the entire feed instead of just the delta like rsync does.
The command line options --rsync, --curl and --wget are removed.

Backport of #478 