### PR TITLE
Prevent deadlock, ensure that no locks are being held at the time of forking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set status finished and send a message if the port list is invalid. [#453](https://github.com/greenbone/openvas/pull/453)
 - Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
 - Clean the new kb when the scan was stopped and the host has not been started. [#494](https://github.com/greenbone/openvas/pull/494)
+- Prevent child deadlock. [#491](https://github.com/greenbone/openvas/pull/491)
 
 [Unreleased]: https://github.com/greenbone/openvas/compare/openvas-7.0...master
 

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -42,6 +42,12 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "alive detection"
+
 struct scanner scanner;
 struct scan_restrictions scan_restrictions;
 struct hosts_data hosts_data;

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -46,7 +46,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive detection"
+#define G_LOG_DOMAIN "alive scan"
 
 struct scanner scanner;
 struct scan_restrictions scan_restrictions;

--- a/src/openvas_log_conf.cmake_in
+++ b/src/openvas_log_conf.cmake_in
@@ -10,7 +10,7 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/openvas.log
 level=127
 
-[alive detection]
+[alive scan]
 prepend=%t %s %p
 separator=:
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z

--- a/src/openvas_log_conf.cmake_in
+++ b/src/openvas_log_conf.cmake_in
@@ -10,6 +10,13 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/openvas.log
 level=127
 
+[alive detection]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/openvas.log
+level=16
+
 [*]
 prepend=%t %s %p
 separator=:

--- a/src/processes.c
+++ b/src/processes.c
@@ -27,8 +27,9 @@
 
 #include "sighand.h"
 
-#include <errno.h> /* for errno() */
-#include <glib.h>  /* for g_error */
+#include <errno.h>            /* for errno() */
+#include <glib.h>             /* for g_error */
+#include <gvm/base/logging.h> /* for gvm_log_lock/unlock() */
 #include <setjmp.h>
 #include <signal.h>   /* for kill() */
 #include <stdlib.h>   /* for exit() */
@@ -36,8 +37,6 @@
 #include <sys/wait.h> /* for waitpid() */
 #include <time.h>     /* for time() */
 #include <unistd.h>   /* for fork() */
-
-#include <gvm/base/logging.h>      /* for gvm_log_lock/unlock() */
 
 #undef G_LOG_DOMAIN
 /**

--- a/src/processes.c
+++ b/src/processes.c
@@ -37,6 +37,8 @@
 #include <time.h>     /* for time() */
 #include <unistd.h>   /* for fork() */
 
+#include <gvm/base/logging.h>      /* for gvm_log_lock/unlock() */
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
@@ -90,8 +92,6 @@ init_child_signal_handlers (void)
   openvas_signal (SIGPIPE, SIG_IGN);
 }
 
-extern GMutex *logger_mutex;
-
 /**
  * @brief Create a new process (fork).
  */
@@ -100,9 +100,9 @@ create_process (process_func_t function, void *argument)
 {
   int pid;
 
-  g_mutex_lock (logger_mutex);
+  gvm_log_lock ();
   pid = fork ();
-  g_mutex_unlock (logger_mutex);
+  gvm_log_unlock ();
 
   if (pid == 0)
     {

--- a/src/processes.c
+++ b/src/processes.c
@@ -90,6 +90,8 @@ init_child_signal_handlers (void)
   openvas_signal (SIGPIPE, SIG_IGN);
 }
 
+extern GMutex *logger_mutex;
+
 /**
  * @brief Create a new process (fork).
  */
@@ -98,7 +100,9 @@ create_process (process_func_t function, void *argument)
 {
   int pid;
 
+  g_mutex_lock (logger_mutex);
   pid = fork ();
+  g_mutex_unlock (logger_mutex);
 
   if (pid == 0)
     {


### PR DESCRIPTION
During testing, the child deadlock was reproduce, right after fork()'ing, when logging the message
"Testing xxx.xxx.xxx.xxx (Vhost...."

Before, since alive detection is running in a thread, it can lock a mutex when the main process is forking a new child. This mutex is copied into the child process in its locked state, and any child that tries to lock the mutex waits forever.

Also, add log domain for alive detection.
