### PR TITLE
Move one CHANGELOG.md entry to the better fitting subheader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Create greenbone-nvt-sync create lock file during feed sync.
   [#458](https://github.com/greenbone/openvas/pull/458)
   [#459](https://github.com/greenbone/openvas/pull/459)
-- Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
 - Extend script_get_preference() to get the value by id. [#470](https://github.com/greenbone/openvas/pull/470)
 - Add extended environmental variables info to greenbone-nvt-sync help text. [#488](https://github.com/greenbone/openvas/pull/488)
 
@@ -29,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wait for all children instead of waiting just for one a time. [#428](https://github.com/greenbone/openvas/pull/428)
 - Don't detect MongoDB as a HTTP service. [#447](https://github.com/greenbone/openvas/pull/447)
 - Set status finished and send a message if the port list is invalid. [#453](https://github.com/greenbone/openvas/pull/453)
+- Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
 
 [Unreleased]: https://github.com/greenbone/openvas/compare/openvas-7.0...master
 


### PR DESCRIPTION
A fix should be placed into the "Fixed" subheader.