### PR TITLE
Clean a new kb when the scan was stopped and the host has not been started.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Don't detect MongoDB as a HTTP service. [#447](https://github.com/greenbone/openvas/pull/447)
 - Set status finished and send a message if the port list is invalid. [#453](https://github.com/greenbone/openvas/pull/453)
 - Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
+- Clean the new kb when the scan was stopped and the host has not been started. [#494](https://github.com/greenbone/openvas/pull/494)
 
 [Unreleased]: https://github.com/greenbone/openvas/compare/openvas-7.0...master
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -1300,12 +1300,14 @@ attack_network (struct scan_globals *globals, kb_t *network_kb)
       host_str = gvm_host_value_str (host);
       if (hosts_new (host_str, host_kb) < 0)
         {
+          kb_delete (host_kb);
           g_free (host_str);
           goto scan_stop;
         }
 
       if (scan_is_stopped ())
         {
+          kb_delete (host_kb);
           g_free (host_str);
           continue;
         }


### PR DESCRIPTION
This avoid a kb to not be cleaned up after stopping a scan for hosts which have not been forked (the kb is empty and ospd-openvas will not clean the kb neither.)