### PR TITLE
Unify log messages about start/end of scan and of hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Don't reload the plugins when start a new scan. [#458](https://github.com/greenbone/openvas/pull/458)
 - Drop http feed sync. [#478](https://github.com/greenbone/openvas/pull/478)
 - Add aligned summary to log at scan end. [#496](https://github.com/greenbone/openvas/pull/496)
+- Unify log messages about start/end of scan and of hosts. [#500](https://github.com/greenbone/openvas/pull/500)
 
 ### Fixed
 - Improve signal handling when update vhosts list. [#425](https://github.com/greenbone/openvas/pull/425)

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -1366,9 +1366,9 @@ scan (alive_test_t alive_test)
       return -2;
     }
 
-  scan_id = get_openvas_scan_id(prefs_get("db_address"), scandb_id);
-  g_message ("Alive scan %s started: Target has %d hosts",
-             scan_id, number_of_targets);
+  scan_id = get_openvas_scan_id(prefs_get ("db_address"), scandb_id);
+  g_message ("Alive scan %s started: Target has %d hosts", scan_id,
+             number_of_targets);
 
   /* Start sniffer thread. */
   err = pthread_create (&sniffer_thread_id, NULL, sniffer_thread, NULL);

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -1349,14 +1349,13 @@ scan (alive_test_t alive_test)
   int err;
   void *retval;
   pthread_t sniffer_thread_id;
-  gchar *scan_id = NULL;
   GHashTableIter target_hosts_iter;
   gpointer key, value;
   struct timeval start_time, end_time;
   int scandb_id = atoi (prefs_get ("ov_maindbid"));
+  gchar *scan_id;
   kb_t main_kb = NULL;
 
-  g_message ("Alive scan started");
   gettimeofday (&start_time, NULL);
   number_of_targets = g_hash_table_size (hosts_data.targethosts);
 
@@ -1366,6 +1365,10 @@ scan (alive_test_t alive_test)
       g_warning ("%s: Unable to open valid pcap handle.", __func__);
       return -2;
     }
+
+  scan_id = get_openvas_scan_id(prefs_get("db_address"), scandb_id);
+  g_message ("Alive scan %s started: Target has %d hosts",
+             scan_id, number_of_targets);
 
   /* Start sniffer thread. */
   err = pthread_create (&sniffer_thread_id, NULL, sniffer_thread, NULL);
@@ -1607,7 +1610,7 @@ scan (alive_test_t alive_test)
   number_of_dead_hosts = send_dead_hosts_to_ospd_openvas ();
 
   gettimeofday (&end_time, NULL);
-  scan_id = get_openvas_scan_id (prefs_get ("db_address"), scandb_id);
+
   g_message ("Alive scan %s finished in %ld seconds: %d alive hosts of %d.",
              scan_id, end_time.tv_sec - start_time.tv_sec,
              number_of_targets - number_of_dead_hosts, number_of_targets);

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -1366,7 +1366,7 @@ scan (alive_test_t alive_test)
       return -2;
     }
 
-  scan_id = get_openvas_scan_id(prefs_get ("db_address"), scandb_id);
+  scan_id = get_openvas_scan_id (prefs_get ("db_address"), scandb_id);
   g_message ("Alive scan %s started: Target has %d hosts", scan_id,
              number_of_targets);
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -650,9 +650,9 @@ attack_start (struct attack_start_args *args)
     }
   hostnames = vhosts_to_str (args->host->vhosts);
   if (hostnames)
-    g_message ("Testing %s (Vhosts: %s) [%d]", ip_str, hostnames, getpid ());
+    g_message ("Vulnerability scan %s started for host: %s (Vhosts: %s)", globals->scan_id, ip_str, hostnames);
   else
-    g_message ("Testing %s [%d]", ip_str, getpid ());
+    g_message ("Vulnerability scan %s started for host: %s", globals->scan_id, ip_str);
   g_free (hostnames);
   attack_host (globals, &hostip, args->host->vhosts, args->sched, kb);
 
@@ -666,7 +666,8 @@ attack_start (struct attack_start_args *args)
           then.tv_sec++;
           now.tv_usec += 1000000;
         }
-      g_message ("Finished testing %s. Time : %ld.%.2ld secs", ip_str,
+      g_message ("Vulnerability scan %s finished for host %s in %ld.%.2ld seconds",
+                 globals->scan_id, ip_str,
                  (long) (now.tv_sec - then.tv_sec),
                  (long) ((now.tv_usec - then.tv_usec) / 10000));
     }
@@ -1019,10 +1020,6 @@ attack_network (struct scan_globals *globals)
   max_hosts = get_max_hosts_number ();
   max_checks = get_max_checks_number ();
 
-  g_message ("Starts a new scan. Target(s) : %s, with max_hosts = %d and "
-             "max_checks = %d",
-             hostlist, max_hosts, max_checks);
-
   hosts = gvm_hosts_new (hostlist);
   unresolved = gvm_hosts_resolve (hosts);
   while (unresolved)
@@ -1044,6 +1041,11 @@ attack_network (struct scan_globals *globals)
   if (host == NULL)
     goto stop;
   hosts_init (max_hosts);
+
+  g_message ("Vulnerability scan %s started: Target has %d hosts",
+             globals->scan_id, gvm_hosts_count (hosts));
+  g_debug ("  Target(s): %s, with max_hosts = %d and max_checks = %d",
+           hostlist, max_hosts, max_checks);
 
   if (test_alive_hosts_only)
     {
@@ -1172,7 +1174,7 @@ attack_network (struct scan_globals *globals)
    * to terminate. */
   while (hosts_read () == 0)
     ;
-  g_message ("Test complete");
+  g_debug ("Test complete");
 
 scan_stop:
   /* Free the memory used by the files uploaded by the user, if any. */

--- a/src/attack.c
+++ b/src/attack.c
@@ -650,9 +650,11 @@ attack_start (struct attack_start_args *args)
     }
   hostnames = vhosts_to_str (args->host->vhosts);
   if (hostnames)
-    g_message ("Vulnerability scan %s started for host: %s (Vhosts: %s)", globals->scan_id, ip_str, hostnames);
+    g_message ("Vulnerability scan %s started for host: %s (Vhosts: %s)",
+               globals->scan_id, ip_str, hostnames);
   else
-    g_message ("Vulnerability scan %s started for host: %s", globals->scan_id, ip_str);
+    g_message ("Vulnerability scan %s started for host: %s", globals->scan_id,
+               ip_str);
   g_free (hostnames);
   attack_host (globals, &hostip, args->host->vhosts, args->sched, kb);
 
@@ -666,10 +668,11 @@ attack_start (struct attack_start_args *args)
           then.tv_sec++;
           now.tv_usec += 1000000;
         }
-      g_message ("Vulnerability scan %s finished for host %s in %ld.%.2ld seconds",
-                 globals->scan_id, ip_str,
-                 (long) (now.tv_sec - then.tv_sec),
-                 (long) ((now.tv_usec - then.tv_usec) / 10000));
+      g_message (
+        "Vulnerability scan %s finished for host %s in %ld.%.2ld seconds",
+        globals->scan_id, ip_str,
+        (long) (now.tv_sec - then.tv_sec),
+        (long) ((now.tv_usec - then.tv_usec) / 10000));
     }
 }
 
@@ -1044,8 +1047,8 @@ attack_network (struct scan_globals *globals)
 
   g_message ("Vulnerability scan %s started: Target has %d hosts",
              globals->scan_id, gvm_hosts_count (hosts));
-  g_debug ("  Target(s): %s, with max_hosts = %d and max_checks = %d",
-           hostlist, max_hosts, max_checks);
+  g_debug ("  Target(s): %s, with max_hosts = %d and max_checks = %d", hostlist,
+           max_hosts, max_checks);
 
   if (test_alive_hosts_only)
     {

--- a/src/attack.c
+++ b/src/attack.c
@@ -670,8 +670,7 @@ attack_start (struct attack_start_args *args)
         }
       g_message (
         "Vulnerability scan %s finished for host %s in %ld.%.2ld seconds",
-        globals->scan_id, ip_str,
-        (long) (now.tv_sec - then.tv_sec),
+        globals->scan_id, ip_str, (long) (now.tv_sec - then.tv_sec),
         (long) ((now.tv_usec - then.tv_usec) / 10000));
     }
 }


### PR DESCRIPTION
This patch unifies the strings send to the log about start and finish of scans
as well as of start and fnish of host vulnerability scans.

The scan_id is always added, so that during parallel scans it is clear
which entry belong to which scan. Now easy to filter activity of a single scan from the log.

Adding the PID to the log message removed. The PID is already part of the log message
as a standard.

Downgraded a redundant scan progress information.
