### PR TITLE
Memleak fixes for kb_item_get_str()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix format-truncation warning in GCC 8.2 and later. [#461](https://github.com/greenbone/openvas/pull/461)
 - Clean the new kb when the scan was stopped and the host has not been started. [#494](https://github.com/greenbone/openvas/pull/494)
 - Prevent child deadlock. [#491](https://github.com/greenbone/openvas/pull/491)
+- Memleak fixes for kb_item_get_str(). [#502](https://github.com/greenbone/openvas/pull/502)
 
 ### Removed
 - Removed "network scan" mode. This includes removal of NASL API methods "scan_phase()" and "network_targets()". Sending a "network_mode=yes" in a scanner configuration will have no effect anymore. [#493](https://github.com/greenbone/openvas/pull/493)

--- a/misc/network.c
+++ b/misc/network.c
@@ -709,6 +709,10 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
   if (open_SSL_connection (fp, cert, key, passwd, cafile, hostname) <= 0)
     {
       g_free (hostname);
+      g_free (cert);
+      g_free (key);
+      g_free (passwd);
+      g_free (cafile);
       g_message ("Function socket_negotiate_ssl called from %s: "
                  "SSL/TLS connection failed.",
                  nasl_get_plugin_filename ());
@@ -716,6 +720,10 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
       return -1;
     }
   g_free (hostname);
+  g_free (cert);
+  g_free (key);
+  g_free (passwd);
+  g_free (cafile);
   return fd;
 }
 

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -100,10 +100,6 @@ _http_req (lex_ctxt *lexic, char *keyword)
 
   kb = plug_get_kb (script_infos);
   g_snprintf (tmp, sizeof (tmp), "/tmp/http/auth/%d", port);
-  auth = kb_item_get_str (kb, tmp);
-
-  if (!auth)
-    auth = kb_item_get_str (kb, "http/auth");
 
   g_snprintf (tmp, sizeof (tmp), "http/%d", port);
   ver = kb_item_get_int (kb, tmp);
@@ -160,10 +156,15 @@ Accept-Charset: iso-8859-1,*,utf-8\r\n",
   else
     request = build_encode_URL (keyword, NULL, item, "HTTP/1.0\r\n");
 
+  auth = kb_item_get_str (kb, tmp);
+  if (!auth)
+    auth = kb_item_get_str (kb, "http/auth");
+
   if (auth)
     {
       char *tmp = g_strconcat (request, auth, "\r\n", NULL);
       g_free (request);
+      g_free (auth);
       request = tmp;
     }
   if (data)

--- a/src/attack.c
+++ b/src/attack.c
@@ -146,6 +146,7 @@ set_scan_status (char *status)
   snprintf (buffer, sizeof (buffer), "internal/%s", scan_id);
   kb_item_set_str (main_kb, buffer, status, 0);
   kb_lnk_reset (main_kb);
+  g_free (scan_id);
 }
 
 /**


### PR DESCRIPTION
Function kb_item_get_str() returns a string that needs to be free'd.

There are a couple of cases where the free() was missing.