### PR TITLE
Simplify icmp

### DIFF
--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -826,7 +826,6 @@ send_icmp (__attribute__ ((unused)) gpointer key, gpointer value,
   struct in_addr *dst4_p = &dst4;
 
   /* For setting the socket option SO_BINDTODEVICE only once */
-  static gboolean icmpv4socopt_set = FALSE;
   static gboolean icmpv6socopt_set = FALSE;
 
   static int count = 0;
@@ -871,30 +870,6 @@ send_icmp (__attribute__ ((unused)) gpointer key, gpointer value,
   else
     {
       dst4.s_addr = dst6_p->s6_addr32[3];
-
-      /* set device for icmpv6 */
-      if (!icmpv4socopt_set)
-        {
-          struct ifreq if_bind;
-          gchar *interface;
-
-          interface = routethrough (dst4_p, NULL);
-          if (!interface)
-            g_debug ("%s: no appropriate interface was found", __func__);
-          if (g_strlcpy (if_bind.ifr_name, interface, IFNAMSIZ) <= 0)
-            g_debug ("%s: copied 0 length interface", __func__);
-
-          if (setsockopt (scanner.icmpv4soc, SOL_SOCKET, SO_BINDTODEVICE,
-                          interface, IFNAMSIZ)
-              < 0)
-            {
-              g_warning ("%s: failed to set socket option SO_BINDTODEVICE: %s",
-                         __func__, strerror (errno));
-              return;
-            }
-          icmpv4socopt_set = TRUE;
-        }
-      /* send packets */
       send_icmp_v4 (scanner.icmpv4soc, dst4_p);
     }
 }

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -780,23 +780,21 @@ send_icmp_v6 (int soc, struct in6_addr *dst, int type)
 static void
 send_icmp_v4 (int soc, struct in_addr *dst)
 {
-  char sendbuf[1500];
+  /* datalen + MAXIPLEN + MAXICMPLEN */
+  char sendbuf[56 + 60 + 76];
   struct sockaddr_in soca;
 
   int len;
   int datalen = 56;
-  struct icmp *icmp;
+  struct icmphdr *icmp;
 
-  icmp = (struct icmp *) sendbuf;
-  icmp->icmp_type = ICMP_ECHO;
-  icmp->icmp_code = 0;
-  icmp->icmp_id = 234;
-  icmp->icmp_seq = 0;
-  memset (icmp->icmp_data, 0xa5, datalen);
+  icmp = (struct icmphdr *) sendbuf;
+  icmp->type = ICMP_ECHO;
+  icmp->code = 0;
 
   len = 8 + datalen;
-  icmp->icmp_cksum = 0;
-  icmp->icmp_cksum = in_cksum ((u_short *) icmp, len);
+  icmp->checksum = 0;
+  icmp->checksum = in_cksum ((u_short *) icmp, len);
 
   memset (&soca, 0, sizeof (soca));
   soca.sin_family = AF_INET;


### PR DESCRIPTION
Do not use `v6_routethrough()` or `routethrough()` anymore for ICMP.