### PR TITLE
Simplify TCP ping IPv6

### DIFF
--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -92,9 +92,6 @@ struct scanner
   uint8_t tcp_flag;
   /* ports used for TCP ACK/SYN */
   GArray *ports;
-  /* source addresses */
-  struct in_addr *sourcev4;
-  struct in6_addr *sourcev6;
   /* redis connection */
   kb_t main_kb;
   /* pcap handle */
@@ -1958,9 +1955,6 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
   if ((error = set_all_needed_sockets (alive_test)) != 0)
     return error;
 
-  /* sources */
-  scanner.sourcev4 = NULL;
-  scanner.sourcev6 = NULL;
   /* kb_t redis connection */
   int scandb_id = atoi (prefs_get ("ov_maindbid"));
   if ((scanner.main_kb = kb_direct_conn (prefs_get ("db_address"), scandb_id))
@@ -2121,10 +2115,6 @@ alive_detection_free (void *error)
       g_warning ("%s: error in kb_lnk_reset()", __func__);
       *(int *) error = BOREAS_CLEANUP_ERROR;
     }
-
-  /* addresses */
-  g_free (scanner.sourcev4);
-  g_free (scanner.sourcev6);
 
   /* Ports array. */
   g_array_free (scanner.ports, TRUE);

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -87,6 +87,7 @@ struct scanner
   int arpv6soc;
   /* UDP socket needed for getting the source IP for the TCP header. */
   int udpv4soc;
+  int udpv6soc;
   /* TH_SYN or TH_ACK */
   uint8_t tcp_flag;
   /* ports used for TCP ACK/SYN */
@@ -1675,6 +1676,17 @@ set_socket (socket_type_t socket_type, int *scanner_socket)
           }
       }
       break;
+    case UDPV6:
+      {
+        soc = socket (AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        if (soc < 0)
+          {
+            g_warning ("%s: failed to open UDPV4 socket: %s", __func__,
+                       strerror (errno));
+            error = BOREAS_OPENING_SOCKET_FAILED;
+          }
+      }
+      break;
     case TCPV4:
       {
         soc = socket (AF_INET, SOCK_RAW, IPPROTO_RAW);
@@ -1802,6 +1814,8 @@ set_all_needed_sockets (alive_test_t alive_test)
       if ((error = set_socket (TCPV6, &scanner.tcpv6soc)) != 0)
         return error;
       if ((error = set_socket (UDPV4, &scanner.udpv4soc)) != 0)
+        return error;
+      if ((error = set_socket (UDPV6, &scanner.udpv6soc)) != 0)
         return error;
     }
 
@@ -2003,6 +2017,12 @@ alive_detection_free (void *error)
               *(int *) error = BOREAS_CLEANUP_ERROR;
             }
           if ((close (scanner.udpv4soc)) != 0)
+            {
+              g_warning ("%s: Error in close(): %s", __func__,
+                         strerror (errno));
+              *(int *) error = BOREAS_CLEANUP_ERROR;
+            }
+          if ((close (scanner.udpv6soc)) != 0)
             {
               g_warning ("%s: Error in close(): %s", __func__,
                          strerror (errno));

--- a/src/alivedetection.c
+++ b/src/alivedetection.c
@@ -1104,6 +1104,7 @@ send_tcp_v4 (int soc, struct in_addr *dst_p, uint8_t tcp_flag)
       inet_ntop (AF_INET, &(dst_p->s_addr), destination_str, INET_ADDRSTRLEN);
       g_debug ("%s: Destination: %s. %s", __func__, destination_str,
                str_boreas_error (error));
+      return;
     }
 
   /* For ports in ports array send packet. */

--- a/src/alivedetection.h
+++ b/src/alivedetection.h
@@ -84,6 +84,7 @@ typedef enum
   ARPV4,
   ARPV6,
   UDPV4,
+  UDPV6,
 } socket_type_t;
 
 #endif

--- a/src/alivedetection_tests.c
+++ b/src/alivedetection_tests.c
@@ -116,14 +116,14 @@ Ensure (alivedetection, set_all_needed_sockets)
   /* All methods set. */
   alive_test = ALIVE_TEST_TCP_ACK_SERVICE | ALIVE_TEST_ICMP | ALIVE_TEST_ARP
                | ALIVE_TEST_CONSIDER_ALIVE | ALIVE_TEST_TCP_SYN_SERVICE;
-  expect (__wrap_socket, will_return (5), times (7));
-  expect (__wrap_setsockopt, will_return (5), times (9));
+  expect (__wrap_socket, will_return (5), times (8));
+  expect (__wrap_setsockopt, will_return (5), times (10));
   set_all_needed_sockets (alive_test);
 
   /* Only one method set. */
   alive_test = ALIVE_TEST_TCP_ACK_SERVICE;
-  expect (__wrap_socket, will_return (5), times (3));
-  expect (__wrap_setsockopt, will_return (5), times (5));
+  expect (__wrap_socket, will_return (5), times (4));
+  expect (__wrap_setsockopt, will_return (5), times (6));
   set_all_needed_sockets (alive_test);
 
   /* ALIVE_TEST_CONSIDER_ALIVE set. */
@@ -181,6 +181,32 @@ Ensure (alivedetection, get_source_addr_v4)
 
   /* Close socket. */
   close (udpv4soc);
+}
+
+Ensure (alivedetection, get_source_addr_v6)
+{
+  int udpv6soc;
+  struct in6_addr dst;
+  struct in6_addr src;
+  boreas_error_t error;
+
+  /* Open socket. */
+  set_socket (UDPV6, &udpv6soc);
+
+  /* Localhost. */
+  inet_pton (AF_INET6, "::FFFF:127.0.0.1", &(dst));
+  error = get_source_addr_v6 (&udpv6soc, &dst, &src);
+  assert_that (error, is_equal_to (NO_ERROR));
+  assert_that (!IN6_IS_ADDR_UNSPECIFIED (&src));
+
+  /* Dependent on local IPv6 configuration. */
+  // inet_pton (AF_INET6, "2001:0db8:0:f101::2", &(dst));
+  // error = get_source_addr_v6 (&udpv6soc, &dst, &src);
+  // assert_that (error, is_equal_to (NO_ERROR));
+  // assert_that (!IN6_IS_ADDR_UNSPECIFIED (&src));
+
+  /* Close socket. */
+  close (udpv6soc);
 }
 
 /* If dst for routethrough() is localhost "lo" interface is returned. */
@@ -406,6 +432,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, alivedetection, set_all_needed_sockets);
   add_test_with_context (suite, alivedetection, set_socket);
   add_test_with_context (suite, alivedetection, get_source_addr_v4);
+  add_test_with_context (suite, alivedetection, get_source_addr_v6);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
* Do not use `routethrough()` for getting the source address. Open udp socket, `connect()` and use `getsockname()` for acquiring the src addr instead.
* Add test
