### PR TITLE
Extend function to generated result from NVTs with a new parameter "uri"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#459](https://github.com/greenbone/openvas/pull/459)
 - Extend script_get_preference() to get the value by id. [#470](https://github.com/greenbone/openvas/pull/470)
 - Add extended environmental variables info to greenbone-nvt-sync help text. [#488](https://github.com/greenbone/openvas/pull/488)
+- Extend nasl functions which generate results with optional "uri" parameter [#526](https://github.com/greenbone/openvas/pull/526)
 
 ### Changed
 - The logging of the NASL internal regexp functions was extended to include the pattern in case of a failed regcomp(). [#397](https://github.com/greenbone/openvas/pull/397)

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -305,7 +305,8 @@ plug_get_host_ip_str (struct script_infos *desc)
  */
 void
 proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
-                    const char *proto, const char *action, const char *what)
+                    const char *proto, const char *action, const char *what,
+                    const char *uri)
 {
   const char *hostname = "";
   char *buffer, *data, port_s[16] = "general";
@@ -333,8 +334,8 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
   else if (desc->vhosts)
     hostname = ((gvm_vhost_t *) desc->vhosts->data)->value;
   addr6_to_str (plug_get_host_ip (desc), ip_str);
-  buffer = g_strdup_printf ("%s|||%s|||%s/%s|||%s|||%s", what, hostname ?: " ",
-                            port_s, proto, oid, action_str->str);
+  buffer = g_strdup_printf ("%s|||%s|||%s/%s|||%s|||%s|||%s", what, hostname ?: " ",
+                            port_s, proto, oid, action_str->str, uri ?: "");
   /* Convert to UTF-8 before sending to Manager. */
   data = g_convert (buffer, -1, "UTF-8", "ISO_8859-1", NULL, &length, NULL);
   kb = plug_get_kb (desc);
@@ -346,16 +347,16 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
 
 void
 proto_post_alarm (const char *oid, struct script_infos *desc, int port,
-                  const char *proto, const char *action)
+                  const char *proto, const char *action, const char *uri)
 {
-  proto_post_wrapped (oid, desc, port, proto, action, "ALARM");
+  proto_post_wrapped (oid, desc, port, proto, action, "ALARM", uri);
 }
 
 void
 post_alarm (const char *oid, struct script_infos *desc, int port,
-            const char *action)
+            const char *action, const char *uri)
 {
-  proto_post_alarm (oid, desc, port, "tcp", action);
+  proto_post_alarm (oid, desc, port, "tcp", action, uri);
 }
 
 /**
@@ -363,9 +364,9 @@ post_alarm (const char *oid, struct script_infos *desc, int port,
  */
 void
 proto_post_log (const char *oid, struct script_infos *desc, int port,
-                const char *proto, const char *action)
+                const char *proto, const char *action, const char *uri)
 {
-  proto_post_wrapped (oid, desc, port, proto, action, "LOG");
+  proto_post_wrapped (oid, desc, port, proto, action, "LOG", uri);
 }
 
 /**
@@ -375,21 +376,32 @@ void
 post_log (const char *oid, struct script_infos *desc, int port,
           const char *action)
 {
-  proto_post_log (oid, desc, port, "tcp", action);
+  proto_post_log (oid, desc, port, "tcp", action, NULL);
 }
+
+/**
+ * @brief Post a log message about a tcp port with a uri
+ */
+void
+post_log_with_uri (const char *oid, struct script_infos *desc, int port,
+                        const char *action, const char *uri)
+{
+  proto_post_log (oid, desc, port, "tcp", action, uri);
+}
+
 
 void
 proto_post_error (const char *oid, struct script_infos *desc, int port,
-                  const char *proto, const char *action)
+                  const char *proto, const char *action, const char *uri)
 {
-  proto_post_wrapped (oid, desc, port, proto, action, "ERRMSG");
+  proto_post_wrapped (oid, desc, port, proto, action, "ERRMSG", uri);
 }
 
 void
 post_error (const char *oid, struct script_infos *desc, int port,
-            const char *action)
+            const char *action, const char *uri)
 {
-  proto_post_error (oid, desc, port, "tcp", action);
+  proto_post_error (oid, desc, port, "tcp", action, uri);
 }
 
 /**

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -334,8 +334,9 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
   else if (desc->vhosts)
     hostname = ((gvm_vhost_t *) desc->vhosts->data)->value;
   addr6_to_str (plug_get_host_ip (desc), ip_str);
-  buffer = g_strdup_printf ("%s|||%s|||%s/%s|||%s|||%s|||%s", what, hostname ?: " ",
-                            port_s, proto, oid, action_str->str, uri ?: "");
+  buffer =
+    g_strdup_printf ("%s|||%s|||%s/%s|||%s|||%s|||%s", what, hostname ?: " ",
+                     port_s, proto, oid, action_str->str, uri ?: "");
   /* Convert to UTF-8 before sending to Manager. */
   data = g_convert (buffer, -1, "UTF-8", "ISO_8859-1", NULL, &length, NULL);
   kb = plug_get_kb (desc);
@@ -384,11 +385,10 @@ post_log (const char *oid, struct script_infos *desc, int port,
  */
 void
 post_log_with_uri (const char *oid, struct script_infos *desc, int port,
-                        const char *action, const char *uri)
+                   const char *action, const char *uri)
 {
   proto_post_log (oid, desc, port, "tcp", action, uri);
 }
-
 
 void
 proto_post_error (const char *oid, struct script_infos *desc, int port,

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -302,6 +302,7 @@ plug_get_host_ip_str (struct script_infos *desc)
  * @param proto Protocol related to the issue (tcp or udp).
  * @param action The actual result text
  * @param what   The type, like "LOG".
+ * @param uri   Location like file path or webservice URL.
  */
 void
 proto_post_wrapped (const char *oid, struct script_infos *desc, int port,

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -117,7 +117,7 @@ post_log (const char *, struct script_infos *, int, const char *);
 
 void
 post_log_with_uri (const char *, struct script_infos *, int, const char *,
-                        const char *);
+                   const char *);
 
 #define post_log_tcp post_log
 

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -88,29 +88,36 @@ plug_create_from_nvti_and_prefs (const nvti_t *);
 
 void
 proto_post_alarm (const char *, struct script_infos *, int, const char *,
-                  const char *);
+                  const char *, const char *);
 
 void
-post_alarm (const char *, struct script_infos *, int, const char *);
+post_alarm (const char *, struct script_infos *, int, const char *,
+            const char *);
 
 void
-post_alarm_udp (struct script_infos *, int, const char *);
+post_alarm_udp (struct script_infos *, int, const char *, const char *);
 
 #define post_alarm_tcp post_alarm
 
 void
 proto_post_error (const char *, struct script_infos *, int, const char *,
-                  const char *);
+                  const char *, const char *);
 void
-post_error (const char *, struct script_infos *, int, const char *);
+post_error (const char *, struct script_infos *, int, const char *,
+            const char *);
 
 #define post_error_tcp post_error
 
 void
 proto_post_log (const char *, struct script_infos *, int, const char *,
-                const char *);
+                const char *, const char *);
+
 void
 post_log (const char *, struct script_infos *, int, const char *);
+
+void
+post_log_with_uri (const char *, struct script_infos *, int, const char *,
+                        const char *);
 
 #define post_log_tcp post_log
 

--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -450,7 +450,8 @@ mark_wild_shell (struct script_infos *desc, int port)
 
   post_alarm (
     oid, desc, port,
-    "A shell seems to be running on this port ! (this is a possible backdoor)");
+    "A shell seems to be running on this port ! (this is a possible backdoor)",
+    NULL);
 }
 
 void
@@ -497,7 +498,7 @@ void
 mark_netbus_server (struct script_infos *desc, int port)
 {
   register_service (desc, port, "netbus");
-  post_alarm (oid, desc, port, "NetBus is running on this port");
+  post_alarm (oid, desc, port, "NetBus is running on this port", NULL);
 }
 
 void
@@ -1030,7 +1031,7 @@ mark_sub7_server (struct script_infos *desc, int port, int trp)
   register_service (desc, port, "sub7");
   snprintf (ban, sizeof (ban), "The Sub7 trojan is running on this port%s",
             get_encaps_through (trp));
-  post_alarm (oid, desc, port, ban);
+  post_alarm (oid, desc, port, ban, NULL);
 }
 
 /*
@@ -1107,7 +1108,7 @@ mark_fssniffer (struct script_infos *desc, int port, int trp)
     snprintf (ban, sizeof (ban),
               "A FsSniffer backdoor seems to be running on this port%s",
               get_encaps_through (trp));
-    post_alarm (oid, desc, port, ban);
+    post_alarm (oid, desc, port, ban, NULL);
   }
 }
 

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -853,7 +853,8 @@ set_kb_item (lex_ctxt *lexic)
  * Function is used when the script wants to report a problem back to openvas.
  */
 typedef void (*proto_post_something_t) (const char *, struct script_infos *,
-                                        int, const char *, const char *, const char *);
+                                        int, const char *, const char *,
+                                        const char *);
 /**
  * Function is used when the script wants to report a problem back to openvas.
  */

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -853,12 +853,12 @@ set_kb_item (lex_ctxt *lexic)
  * Function is used when the script wants to report a problem back to openvas.
  */
 typedef void (*proto_post_something_t) (const char *, struct script_infos *,
-                                        int, const char *, const char *);
+                                        int, const char *, const char *, const char *);
 /**
  * Function is used when the script wants to report a problem back to openvas.
  */
 typedef void (*post_something_t) (const char *, struct script_infos *, int,
-                                  const char *);
+                                  const char *, const char *);
 
 static tree_cell *
 security_something (lex_ctxt *lexic, proto_post_something_t proto_post_func,
@@ -868,6 +868,7 @@ security_something (lex_ctxt *lexic, proto_post_something_t proto_post_func,
 
   char *proto = get_str_var_by_name (lexic, "protocol");
   char *data = get_str_var_by_name (lexic, "data");
+  char *uri = get_str_var_by_name (lexic, "uri");
   int port = get_int_var_by_name (lexic, "port", -1);
   char *dup = NULL;
 
@@ -899,18 +900,18 @@ security_something (lex_ctxt *lexic, proto_post_something_t proto_post_func,
   if (dup != NULL)
     {
       if (proto == NULL)
-        post_func (lexic->oid, script_infos, port, dup);
+        post_func (lexic->oid, script_infos, port, dup, uri);
       else
-        proto_post_func (lexic->oid, script_infos, port, proto, dup);
+        proto_post_func (lexic->oid, script_infos, port, proto, dup, uri);
 
       g_free (dup);
       return FAKE_CELL;
     }
 
   if (proto == NULL)
-    post_func (lexic->oid, script_infos, port, NULL);
+    post_func (lexic->oid, script_infos, port, NULL, uri);
   else
-    proto_post_func (lexic->oid, script_infos, port, proto, NULL);
+    proto_post_func (lexic->oid, script_infos, port, proto, NULL, uri);
 
   return FAKE_CELL;
 }
@@ -931,7 +932,7 @@ security_message (lex_ctxt *lexic)
 tree_cell *
 log_message (lex_ctxt *lexic)
 {
-  return security_something (lexic, proto_post_log, post_log);
+  return security_something (lexic, proto_post_log, post_log_with_uri);
 }
 
 tree_cell *


### PR DESCRIPTION
Since the same nvt can generate more than one result with different location.
e.g. an installed library in two different path.
This add a new field to the results and the same result from the same
host and same OID, can be differentiated.