### PR TITLE
Add trap for removing feed lock file on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve signal handling when update vhosts list. [#426](https://github.com/greenbone/openvas/pull/426)
 - Wait for all children instead of waiting just for one a time. [#429](https://github.com/greenbone/openvas/pull/429)
 - Fix format-truncation warning in GCC 8.2 and later. [#462](https://github.com/greenbone/openvas/pull/462)
+- Fix issue which produced to not remove the feed lock file. [#527](https://github.com/greenbone/openvas/pull/527)
 
 ### Removed
 - Drop HTTP sync [#489](https://github.com/greenbone/openvas/pull/489)

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -513,13 +513,12 @@ do_sync ()
   then
     log_write "Feed is already current, skipping synchronization."
   else
+    trap "rm $OPENVAS_RUN_DIR/feed-update.lock" EXIT HUP INT TRAP TERM
     create_feed_lock_file
     if [ $FEED_LOCKED -eq 1 ] ; then
        exit 1
     fi
-
     sync_nvts
-    rm $OPENVAS_RUN_DIR/feed-update.lock
   fi
 }
 


### PR DESCRIPTION
This avoid to leave the file in case of error and exit from other function.
Closes: #525
Closes: greenbone/ospd-openvas#267
