### PR TITLE
Add nasl function to get the host kb index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extend script_get_preference() to get the value by id. [#470](https://github.com/greenbone/openvas/pull/470)
 - Add extended environmental variables info to greenbone-nvt-sync help text. [#488](https://github.com/greenbone/openvas/pull/488)
 - Extend nasl functions which generate results with optional "uri" parameter [#526](https://github.com/greenbone/openvas/pull/526)
+- Add nasl function to get the host kb index. [#530](https://github.com/greenbone/openvas/pull/530)
 
 ### Changed
 - The logging of the NASL internal regexp functions was extended to include the pattern in case of a failed regcomp(). [#397](https://github.com/greenbone/openvas/pull/397)

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -94,6 +94,7 @@ static init_func libfuncs[] = {
   {"set_kb_item", set_kb_item},
   {"get_kb_item", get_kb_item},
   {"get_kb_list", get_kb_list},
+  {"get_host_kb_index", get_host_kb_index},
   {"security_message", security_message},
   {"log_message", log_message},
   {"error_message", error_message},

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -763,6 +763,33 @@ get_kb_item (lex_ctxt *lexic)
   return retc;
 }
 
+/**
+ * @brief Get the kb index of the host running the current script.
+ *
+ * @param[in] lexic     NASL lexer.
+ *
+ * @return lex cell containing the host kb index value as positive integer.
+ *         NULL otherwise
+ */
+tree_cell *
+get_host_kb_index (lex_ctxt *lexic)
+{
+  struct script_infos *script_infos = lexic->script_infos;
+  int val;
+  tree_cell *retc;
+
+  val = kb_get_kb_index (script_infos->key);
+  if (val >= 0)
+    {
+      retc = alloc_typed_cell (CONST_INT);
+      retc->x.i_val = val;
+    }
+  else
+    return NULL;
+
+  return retc;
+}
+
 tree_cell *
 replace_kb_item (lex_ctxt *lexic)
 {

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -94,6 +94,9 @@ tree_cell *
 get_script_oid (lex_ctxt *);
 
 tree_cell *
+get_host_kb_index (lex_ctxt *);
+
+tree_cell *
 get_kb_item (lex_ctxt *);
 
 tree_cell *


### PR DESCRIPTION
The functions returns a integer, the redis db index of the host kb
related to the host running the plugin.