### PR TITLE
Corrected function parameter names in nasl_perror calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Memleak fixes for kb_item_get_str(). [#502](https://github.com/greenbone/openvas/pull/502)
 - Fix denied hosts.  [#510](https://github.com/greenbone/openvas/pull/510)
 - Fix openvas-nasl. Add kb key/value for all vhosts. [#533](https://github.com/greenbone/openvas/pull/533)
-- Wait for last plugin to finish before change to other category. [#534](https://github.com/greenbone/openvas/pull/534) 
+- Wait for last plugin to finish before change to other category. [#534](https://github.com/greenbone/openvas/pull/534)
+- Corrected function parameter names in nasl_perror calls. [#539](https://github.com/greenbone/openvas/pull/539)
 
 ### Removed
 - Removed "network scan" mode. This includes removal of NASL API methods "scan_phase()" and "network_targets()". Sending a "network_mode=yes" in a scanner configuration will have no effect anymore. [#493](https://github.com/greenbone/openvas/pull/493)

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -196,7 +196,7 @@ get_ipv6_element (lex_ctxt *lexic)
 
   if (ip6 == NULL)
     {
-      nasl_perror (lexic, "get_ipv6_element : no valid 'ip' argument!\n");
+      nasl_perror (lexic, "get_ipv6_element : no valid 'ipv6' argument!\n");
       return NULL;
     }
 
@@ -286,7 +286,7 @@ set_ipv6_elements (lex_ctxt *lexic)
 
   if (o_pkt == NULL)
     {
-      nasl_perror (lexic, "set_ip_elements: missing <ip> field\n");
+      nasl_perror (lexic, "set_ip_elements: missing <ip6> field\n");
       return NULL;
     }
 
@@ -461,7 +461,7 @@ forge_tcp_v6_packet (lex_ctxt *lexic)
   if (ip6 == NULL)
     {
       nasl_perror (lexic,
-                   "forge_tcp_packet : You must supply the 'ip' argument !");
+                   "forge_tcp_packet : You must supply the 'ip6' argument !");
       return NULL;
     }
 


### PR DESCRIPTION
Seems these were some leftovers from some code copy done in greenbone/gvm-libs@ddef947bb72c50f8a4e7743b57db2cc308e2b5ae and greenbone/gvm-libs@063a232fc154af63436ff197eeb316e8e5fdec46