### PR TITLE
Allow all ICMP types in ICMPv6 header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Unify log messages about start/end of scan and of hosts. [#500](https://github.com/greenbone/openvas/pull/500)
 - Use flock to lock the feed lock file. [#507](https://github.com/greenbone/openvas/pull/507)
 - Move alive detection module (Boreas) into gvm-libs [#519](https://github.com/greenbone/openvas/pull/519)
+- Allow to set all legal types of icmp v6 in icmp header in openvas-nasl. [#542](https://github.com/greenbone/openvas/pull/542)
 
 ### Fixed
 - Improve signal handling when update vhosts list. [#425](https://github.com/greenbone/openvas/pull/425)

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -1291,7 +1291,20 @@ forge_icmp_v6_packet (lex_ctxt *lexic)
           break;
         default:
           {
-            nasl_perror (lexic, "forge_icmp_v6_packet: unknown type\n");
+            if (t < 0 || t > 255)
+              {
+                nasl_perror (lexic, "forge_icmp_v6_packet: illegal type %d\n",
+                             t);
+              }
+            else
+              {
+                if (data != NULL)
+                  bcopy (data, &(p[8]), len);
+                icmp->icmp6_id = get_int_var_by_name (lexic, "icmp_id", 0);
+                icmp->icmp6_seq = get_int_var_by_name (lexic, "icmp_seq", 0);
+                size = ip6_sz + 8 + len;
+                sz = 8;
+              }
           }
         }
 


### PR DESCRIPTION
All types of ICMP are supported to be set in the ICMP header.
This does not mean that all ICMP types are fully supported, only that the type can be set for all.
The developer of vts has to check if the disired ICMP type is truly supported by either checking the cource code or monitoring his or her vt via tools like wireshark/tcpdump.