### PR TITLE
Backport fix of icmp checksum calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wait for all children instead of waiting just for one a time. [#429](https://github.com/greenbone/openvas/pull/429)
 - Fix format-truncation warning in GCC 8.2 and later. [#462](https://github.com/greenbone/openvas/pull/462)
 - Fix issue which produced to not remove the feed lock file. [#527](https://github.com/greenbone/openvas/pull/527)
+- Fix icmp checksum calculation in openvas-nasl. [#547](https://github.com/greenbone/openvas/pull/547)
 
 ### Removed
 - Drop HTTP sync [#489](https://github.com/greenbone/openvas/pull/489)

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -1115,8 +1115,11 @@ struct v6pseudo_icmp_hdr
 {
   struct in6_addr s6addr;
   struct in6_addr d6addr;
-  char proto;
   unsigned short len;
+  unsigned char zero1;
+  unsigned char zero2;
+  unsigned char zero3;
+  char proto;
   struct icmp6_hdr icmpheader;
 };
 


### PR DESCRIPTION
This also fixes an issue of not being able to ICMP ping IPv6 addresses.