### PR TITLE
Backport fix of icmp checksum calculation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Main changes compared to openvas-scanner 6.0.1:
 * Perform the scan even if there are missing plugins in the nvticache.
 * Drop HTTP sync.
 * Use new URL for GCF rsync.
+* Fix icmp checksum calculation in openvas-nasl.
 
 openvas-scanner 6.0.1 (2019-07-17)
 

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -1127,8 +1127,11 @@ struct v6pseudo_icmp_hdr
 {
   struct in6_addr s6addr;
   struct in6_addr d6addr;
-  char proto;
   unsigned short len;
+  unsigned char zero1;
+  unsigned char zero2;
+  unsigned char zero3;
+  char proto;
   struct icmp6_hdr icmpheader;
 };
 


### PR DESCRIPTION
This also fixes an issue of not being able to ICMP ping IPv6 addresses.