### PR TITLE
Store results in main_kb instead of host_kb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [unreleased]
+
+### Changed
+-Store results in main_kb instead of host_kb. [#550](https://github.com/greenbone/openvas/pull/550)
+
+[unreleased]: https://github.com/greenbone/openvas/compare/openvas-20.08...master
+
 ## [20.08] (unreleased)
 
 ### Added

--- a/doc/redis_data_model.md
+++ b/doc/redis_data_model.md
@@ -103,6 +103,10 @@ and this KB is released once the complete scan ended. This means, when all
 single hosts in the target were scanned, the main kb data will be deleted
 and the in-use DB list inside the hash `GVM.__GlobalDBIndex` is updated.
 
+The task main KB is used for storing the results. Each result produced by a
+NVT for a host, will be stored in this KB, and the progress status of the
+current scanned hosts as well.
+
 ### Temporary KB for a single host
 Each host to be scanned takes a new DB for the KB. The host KB is used to
 store some scan preferences and results for this specific host. When the host
@@ -186,15 +190,13 @@ DB 2 -> 1) "internal/dbindex"
         2) "internal/ovas_pid"
         3) "internal/acc04534-54b4-4137-a78a-c3d4441ede37"
         4) "internal/scanid"
-        5) "internal/acc04534-54b4-4137-a78a-c3d4441ede37/scanprefs"
-        6) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        5) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        6) "internal/status"
+        7) "internal/results
 
 DB 3 -> 1) "Services/irc"
         2) "www/80/content/cgis//twiki/bin/rdiff/TWiki/TWikiSiteTools"
         3) "internal/ip"
-        4) "internal/start_time"
-        5) "internal/state"
-        6) "internal/results"
         .
         .
         .
@@ -234,15 +236,14 @@ DB 2 -> 1) "internal/dbindex"
         2) "internal/ovas_pid"
         3) "internal/acc04534-54b4-4137-a78a-c3d4441ede37"
         4) "internal/scanid"
-        5) "internal/acc04534-54b4-4137-a78a-c3d4441ede37/scanprefs"
-        6) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        5) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        6) "internal/status"
+        7) "internal/results
+
 
 DB 3 -> 1) "Services/irc"
         2) "www/80/content/cgis//twiki/bin/rdiff/TWiki/TWikiSiteTools"
         3) "internal/ip"
-        4) "internal/start_time"
-        5) "internal/state"
-        6) "internal/results"
         .
         .
         .
@@ -265,9 +266,6 @@ DB 4 -> 1) "Cache/80/URL_/doc/scripts.php"
         .
         1453) "internal/ip"
         1454) "HostDetails/NVT/1.3.6.1.4.1.25623.1.0.111068/OS"
-        1455) "internal/start_time"
-        1456) "internal/state"
-        1457) "internal/results"
         1458) "Cache/80/URL_/test/testoutput/readme.txt"
         1459) "Cache/80/URL_/cgilib/"
 ```
@@ -298,15 +296,13 @@ DB 2 -> 1) "internal/dbindex"
         2) "internal/ovas_pid"
         3) "internal/acc04534-54b4-4137-a78a-c3d4441ede37"
         4) "internal/scanid"
-        5) "internal/acc04534-54b4-4137-a78a-c3d4441ede37/scanprefs"
-        6) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        5) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        6) "internal/status"
+        7) "internal/results
 
 DB 3 -> 1) "Services/irc"
         2) "www/80/content/cgis//twiki/bin/rdiff/TWiki/TWikiSiteTools"
         3) "internal/ip"
-        4) "internal/start_time"
-        5) "internal/state"
-        6) "internal/results"
         .
         .
         .
@@ -324,8 +320,9 @@ DB 4 -> 1) "internal/dbindex"
         2) "internal/ovas_pid"
         3) "internal/da234534-54b4-4137-a78a-c3d4441edd42"
         4) "internal/scanid"
-        5) "internal/da234534-54b4-4137-a78a-c3d4441edd42/scanprefs"
-        6) "internal/91a1d963-d71f-4c98-bc18-c6fae296acd1/globalscanid"
+        5) "internal/91a1d963-d71f-4c98-bc18-c6fae296acd1/globalscanid"
+        6) "internal/status"
+        7) "internal/results
 
 
 DB 5 -> 1) "Cache/80/URL_/doc/scripts.php"
@@ -337,9 +334,6 @@ DB 5 -> 1) "Cache/80/URL_/doc/scripts.php"
         .
         1453) "internal/ip"
         1454) "HostDetails/NVT/1.3.6.1.4.1.25623.1.0.111068/OS"
-        1455) "internal/start_time"
-        1456) "internal/state"
-        1457) "internal/results"
         1458) "Cache/80/URL_/test/testoutput/readme.txt"
         1459) "Cache/80/URL_/cgilib/"
 ```
@@ -372,15 +366,13 @@ DB 2 -> 1) "internal/dbindex"
         2) "internal/ovas_pid"
         3) "internal/acc04534-54b4-4137-a78a-c3d4441ede37"
         4) "internal/scanid"
-        5) "internal/acc04534-54b4-4137-a78a-c3d4441ede37/scanprefs"
-        6) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        5) "internal/dd91d963-d71f-4c98-bc18-c6fae29633aa/globalscanid"
+        6) "internal/status"
+        7) "internal/results
 
 DB 3 -> 1) "Services/irc"
         2) "www/80/content/cgis//twiki/bin/rdiff/TWiki/TWikiSiteTools"
         3) "internal/ip"
-        4) "internal/start_time"
-        5) "internal/state"
-        6) "internal/results"
         .
         .
         .
@@ -403,9 +395,6 @@ DB 4 -> 1) "Cache/80/URL_/doc/scripts.php"
         .
         1453) "internal/ip"
         1454) "HostDetails/NVT/1.3.6.1.4.1.25623.1.0.111068/OS"
-        1455) "internal/start_time"
-        1456) "internal/state"
-        1457) "internal/results"
         1458) "Cache/80/URL_/test/testoutput/readme.txt"
         1459) "Cache/80/URL_/cgilib/"
 
@@ -413,15 +402,13 @@ DB 5 -> 1) "internal/dbindex"
         2) "internal/ovas_pid"
         3) "internal/da234534-54b4-4137-a78a-c3d4441edd42"
         4) "internal/scanid"
-        5) "internal/da234534-54b4-4137-a78a-c3d4441edd42/scanprefs"
-        6) "internal/91a1d963-d71f-4c98-bc18-c6fae296acd1/globalscanid"
+        5) "internal/91a1d963-d71f-4c98-bc18-c6fae296acd1/globalscanid"
+        6) "internal/status"
+        7) "internal/results
 
 DB 6 -> 1) "Services/irc"
         2) "www/80/content/cgis//twiki/bin/rdiff/TWiki/TWikiSiteTools"
         3) "internal/ip"
-        4) "internal/start_time"
-        5) "internal/state"
-        6) "internal/results"
         .
         .
         .
@@ -444,9 +431,6 @@ DB 7 -> 1) "Cache/80/URL_/doc/scripts.php"
         .
         1453) "internal/ip"
         1454) "HostDetails/NVT/1.3.6.1.4.1.25623.1.0.111068/OS"
-        1455) "internal/start_time"
-        1456) "internal/state"
-        1457) "internal/results"
         1458) "Cache/80/URL_/test/testoutput/readme.txt"
         1459) "Cache/80/URL_/cgilib/"
 ```

--- a/doc/redis_data_model.md
+++ b/doc/redis_data_model.md
@@ -103,9 +103,9 @@ and this KB is released once the complete scan ended. This means, when all
 single hosts in the target were scanned, the main kb data will be deleted
 and the in-use DB list inside the hash `GVM.__GlobalDBIndex` is updated.
 
-The task main KB is used for storing the results. Each result produced by a
-NVT for a host, will be stored in this KB, and the progress status of the
-current scanned hosts as well.
+The task main KB is used for storing the results. Each result produced by NVTs
+as well as the the progress status of the currently scanned hosts will be stored
+in this KB.
 
 ### Temporary KB for a single host
 Each host to be scanned takes a new DB for the KB. The host KB is used to

--- a/misc/network.c
+++ b/misc/network.c
@@ -1785,7 +1785,6 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
           if (host_get_port_state (args, port) > 0)
             {
               char ip_str[INET6_ADDRSTRLEN];
-              char key[64];
 
               g_snprintf (buffer, sizeof (buffer), "Ports/tcp/%d", port);
               g_message ("open_sock_tcp: %s:%d too many timeouts. "
@@ -1798,8 +1797,7 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
                         "ERRMSG|||%s|||%s|||%d/tcp||| |||Too many timeouts. The port"
                         " was set to closed.",
                         ip_str, plug_current_vhost () ?: " ", port);
-              snprintf (key, sizeof (key), "internal/results/%s", ip_str);
-              kb_item_push_str (args->results, key, buffer);
+              kb_item_push_str (args->results, "internal/results", buffer);
             }
         }
       g_free (ip_str);

--- a/misc/network.c
+++ b/misc/network.c
@@ -1793,10 +1793,11 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
               kb_item_set_int (kb, buffer, 0);
 
               addr6_to_str (args->ip, ip_str);
-              snprintf (buffer, sizeof (buffer),
-                        "ERRMSG|||%s|||%s|||%d/tcp||| |||Too many timeouts. The port"
-                        " was set to closed.",
-                        ip_str, plug_current_vhost () ?: " ", port);
+              snprintf (
+                buffer, sizeof (buffer),
+                "ERRMSG|||%s|||%s|||%d/tcp||| |||Too many timeouts. The port"
+                " was set to closed.",
+                ip_str, plug_current_vhost () ?: " ", port);
               kb_item_push_str (args->results, "internal/results", buffer);
             }
         }

--- a/misc/network.c
+++ b/misc/network.c
@@ -1785,6 +1785,7 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
           if (host_get_port_state (args, port) > 0)
             {
               char ip_str[INET6_ADDRSTRLEN];
+              char key[64];
 
               g_snprintf (buffer, sizeof (buffer), "Ports/tcp/%d", port);
               g_message ("open_sock_tcp: %s:%d too many timeouts. "
@@ -1797,7 +1798,8 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
                         "ERRMSG|||%s|||%d/tcp||| |||Too many timeouts. The port"
                         " was set to closed.",
                         plug_current_vhost () ?: " ", port);
-              kb_item_push_str (args->key, "internal/results", buffer);
+              snprintf (key, sizeof (key), "internal/results/%s", ip_str);
+              kb_item_push_str (args->results, key, buffer);
             }
         }
       g_free (ip_str);

--- a/misc/network.c
+++ b/misc/network.c
@@ -1795,9 +1795,9 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
 
               addr6_to_str (args->ip, ip_str);
               snprintf (buffer, sizeof (buffer),
-                        "ERRMSG|||%s|||%d/tcp||| |||Too many timeouts. The port"
+                        "ERRMSG|||%s|||%s|||%d/tcp||| |||Too many timeouts. The port"
                         " was set to closed.",
-                        plug_current_vhost () ?: " ", port);
+                        ip_str, plug_current_vhost () ?: " ", port);
               snprintf (key, sizeof (key), "internal/results/%s", ip_str);
               kb_item_push_str (args->results, key, buffer);
             }

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -310,7 +310,7 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
                     const char *uri)
 {
   const char *hostname = "";
-  char *buffer, *data, port_s[16] = "general";
+  char key[64], *buffer, *data, port_s[16] = "general";
   char ip_str[INET6_ADDRSTRLEN];
   GString *action_str;
   gsize length;
@@ -340,8 +340,9 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
                      port_s, proto, oid, action_str->str, uri ?: "");
   /* Convert to UTF-8 before sending to Manager. */
   data = g_convert (buffer, -1, "UTF-8", "ISO_8859-1", NULL, &length, NULL);
-  kb = plug_get_kb (desc);
-  kb_item_push_str (kb, "internal/results", data);
+  kb = plug_get_results_kb (desc);
+  snprintf (key, sizeof (key), "internal/results%s%s", hostname ?"/": "", hostname ?: "");
+  kb_item_push_str (kb, key, data);
   g_free (data);
   g_free (buffer);
   g_string_free (action_str, TRUE);
@@ -671,6 +672,12 @@ kb_t
 plug_get_kb (struct script_infos *args)
 {
   return args->key;
+}
+
+kb_t
+plug_get_results_kb (struct script_infos *args)
+{
+  return args->results;
 }
 
 static void

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -335,9 +335,9 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
   else if (desc->vhosts)
     hostname = ((gvm_vhost_t *) desc->vhosts->data)->value;
   addr6_to_str (plug_get_host_ip (desc), ip_str);
-  buffer =
-    g_strdup_printf ("%s|||%s|||%s|||%s/%s|||%s|||%s|||%s", what, ip_str, hostname ?: " ",
-                     port_s, proto, oid, action_str->str, uri ?: "");
+  buffer = g_strdup_printf ("%s|||%s|||%s|||%s/%s|||%s|||%s|||%s", what, ip_str,
+                            hostname ?: " ", port_s, proto, oid,
+                            action_str->str, uri ?: "");
   /* Convert to UTF-8 before sending to Manager. */
   data = g_convert (buffer, -1, "UTF-8", "ISO_8859-1", NULL, &length, NULL);
   kb = plug_get_results_kb (desc);

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -310,7 +310,7 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
                     const char *uri)
 {
   const char *hostname = "";
-  char key[64], *buffer, *data, port_s[16] = "general";
+  char *buffer, *data, port_s[16] = "general";
   char ip_str[INET6_ADDRSTRLEN];
   GString *action_str;
   gsize length;
@@ -341,8 +341,7 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
   /* Convert to UTF-8 before sending to Manager. */
   data = g_convert (buffer, -1, "UTF-8", "ISO_8859-1", NULL, &length, NULL);
   kb = plug_get_results_kb (desc);
-  snprintf (key, sizeof (key), "internal/results%s%s", ip_str ?"/": "", ip_str ?: "");
-  kb_item_push_str (kb, key, data);
+  kb_item_push_str (kb, "internal/results", data);
   g_free (data);
   g_free (buffer);
   g_string_free (action_str, TRUE);

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -336,12 +336,12 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
     hostname = ((gvm_vhost_t *) desc->vhosts->data)->value;
   addr6_to_str (plug_get_host_ip (desc), ip_str);
   buffer =
-    g_strdup_printf ("%s|||%s|||%s/%s|||%s|||%s|||%s", what, hostname ?: " ",
+    g_strdup_printf ("%s|||%s|||%s|||%s/%s|||%s|||%s|||%s", what, ip_str, hostname ?: " ",
                      port_s, proto, oid, action_str->str, uri ?: "");
   /* Convert to UTF-8 before sending to Manager. */
   data = g_convert (buffer, -1, "UTF-8", "ISO_8859-1", NULL, &length, NULL);
   kb = plug_get_results_kb (desc);
-  snprintf (key, sizeof (key), "internal/results%s%s", hostname ?"/": "", hostname ?: "");
+  snprintf (key, sizeof (key), "internal/results%s%s", ip_str ?"/": "", ip_str ?: "");
   kb_item_push_str (kb, key, data);
   g_free (data);
   g_free (buffer);

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -150,6 +150,9 @@ plug_replace_key_len (struct script_infos *, char *, int, void *, size_t);
 kb_t
 plug_get_kb (struct script_infos *);
 
+kb_t
+plug_get_results_kb (struct script_infos *);
+
 void *
 plug_get_key (struct script_infos *, char *, int *, size_t *, int);
 

--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -42,6 +42,7 @@ struct script_infos
 {
   struct scan_globals *globals;
   kb_t key;
+  kb_t results;
   nvti_t *nvti;
   char *oid;
   char *name;

--- a/src/attack.c
+++ b/src/attack.c
@@ -87,6 +87,7 @@ struct attack_start_args
   struct scan_globals *globals;
   plugins_scheduler_t sched;
   kb_t host_kb;
+  kb_t main_kb;
   gvm_host_t *host;
 };
 
@@ -157,6 +158,7 @@ static int
 comm_send_status (kb_t kb, char *hostname, int curr, int max)
 {
   char buffer[2048];
+  char key[64];
 
   if (!hostname || !kb)
     return -1;
@@ -165,7 +167,8 @@ comm_send_status (kb_t kb, char *hostname, int curr, int max)
     return -1;
 
   snprintf (buffer, sizeof (buffer), "%d/%d", curr, max);
-  kb_item_push_str (kb, "internal/status", buffer);
+  snprintf (key, sizeof (buffer), "internal/status/%s", hostname);
+  kb_item_push_str (kb, key, buffer);
 
   return 0;
 }
@@ -175,10 +178,12 @@ error_message_to_client2 (kb_t kb, const char *msg, const char *ip_str,
                           const char *port)
 {
   char buf[2048];
-
+  char key[64];
+  
   sprintf (buf, "ERRMSG|||%s|||%s||| |||%s", ip_str ?: "", port ?: " ",
            msg ?: "No error.");
-  kb_item_push_str (kb, "internal/results", buf);
+  sprintf (key, "internal/results%s%s", ip_str ?"/": "", ip_str ?: "");
+  kb_item_push_str (kb, key, buf);
 }
 
 static void
@@ -309,7 +314,7 @@ check_new_vhosts (void)
  */
 static int
 launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
-               struct in6_addr *ip, GSList *vhosts, kb_t kb)
+               struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb)
 {
   int optimize = prefs_get_bool ("optimize_test"), pid, ret = 0;
   char *oid, *name, *error = NULL, ip_str[INET6_ADDRSTRLEN];
@@ -386,7 +391,7 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
 
   /* Update vhosts list and start the plugin */
   check_new_vhosts ();
-  pid = plugin_launch (globals, plugin, ip, vhosts, kb, nvti);
+  pid = plugin_launch (globals, plugin, ip, vhosts, kb, main_kb, nvti);
   if (pid < 0)
     {
       plugin->running_state = PLUGIN_STATUS_UNRUN;
@@ -411,7 +416,7 @@ finish_launch_plugin:
  */
 static void
 attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
-             plugins_scheduler_t sched, kb_t kb)
+             plugins_scheduler_t sched, kb_t kb, kb_t main_kb)
 {
   /* Used for the status */
   int num_plugs, forks_retry = 0;
@@ -451,7 +456,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
           static int last_status = 0, cur_plug = 0;
 
         again:
-          e = launch_plugin (globals, plugin, ip, host_vhosts, kb);
+          e = launch_plugin (globals, plugin, ip, host_vhosts, kb, main_kb);
           if (e < 0)
             {
               /*
@@ -460,6 +465,9 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
               if (e == ERR_HOST_DEAD)
                 {
                   char buffer[2048];
+                  char key[64];
+
+                  sprintf (key, "internal/results/%s", ip_str);
                   snprintf (
                     buffer, sizeof (buffer),
                     "LOG||| |||general/Host_Details||| |||<host><detail>"
@@ -469,9 +477,9 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                   /* In case of a dead host, it sends max_ports = -1 to the
                      manager. The host will not be taken into account to
                      calculate the scan progress. */
-                  comm_send_status (kb, ip_str, 0, -1);
+                  comm_send_status (main_kb, ip_str, 0, -1);
 #endif
-                  kb_item_push_str (kb, "internal/results", buffer);
+                  kb_item_push_str (kb, key, buffer);
                   goto host_died;
                 }
               else if (e == ERR_CANT_FORK)
@@ -496,7 +504,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
               && !scan_is_stopped ())
             {
               last_status = (cur_plug * 100) / num_plugs + 2;
-              if (comm_send_status (kb, ip_str, cur_plug, num_plugs) < 0)
+              if (comm_send_status (main_kb, ip_str, cur_plug, num_plugs) < 0)
                 {
                   pluginlaunch_stop ();
                   goto host_died;
@@ -514,7 +522,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
 
   pluginlaunch_wait (kb);
   if (!scan_is_stopped ())
-    comm_send_status (kb, ip_str, num_plugs, num_plugs);
+    comm_send_status (main_kb, ip_str, num_plugs, num_plugs);
 
 host_died:
   pluginlaunch_stop ();
@@ -619,10 +627,12 @@ attack_start (struct attack_start_args *args)
   struct in6_addr hostip;
   struct timeval then;
   kb_t kb = args->host_kb;
+  kb_t main_kb = args->main_kb;
   int ret, ret_host_auth;
 
   nvticache_reset ();
   kb_lnk_reset (kb);
+  kb_lnk_reset (main_kb);
   gettimeofday (&then, NULL);
 
   kb_item_set_str (kb, "internal/scan_id", globals->scan_id, 0);
@@ -641,10 +651,10 @@ attack_start (struct attack_start_args *args)
   if (ret_host_auth < 0)
     {
       if (ret_host_auth == -1)
-        error_message_to_client2 (kb, "Host access denied.", ip_str, NULL);
+        error_message_to_client2 (main_kb, "Host access denied.", ip_str, NULL);
       else
         error_message_to_client2 (
-          kb, "Host access denied (system-wide restriction.)", ip_str, NULL);
+          main_kb, "Host access denied (system-wide restriction.)", ip_str, NULL);
 
       kb_item_set_str (kb, "internal/host_deny", "True", 0);
       g_warning ("Host %s access denied.", ip_str);
@@ -665,7 +675,7 @@ attack_start (struct attack_start_args *args)
     g_message ("Vulnerability scan %s started for host: %s", globals->scan_id,
                ip_str);
   g_free (hostnames);
-  attack_host (globals, &hostip, args->host->vhosts, args->sched, kb);
+  attack_host (globals, &hostip, args->host->vhosts, args->sched, kb, main_kb);
 
   if (!scan_is_stopped ())
     {
@@ -964,6 +974,7 @@ attack_network (struct scan_globals *globals)
   gvm_hosts_t *hosts;
   const gchar *port_range;
   kb_t host_kb;
+  kb_t main_kb;
   GSList *unresolved;
 
   gboolean test_alive_hosts_only = prefs_get_bool ("test_alive_hosts_only");
@@ -988,8 +999,6 @@ attack_network (struct scan_globals *globals)
   port_range = prefs_get ("port_range");
   if (validate_port_range (port_range))
     {
-      kb_t main_kb = NULL;
-
       connect_main_kb (&main_kb);
       error_message_to_client2 (
         main_kb, "Invalid port list. Ports must be in the range [1-65535]",
@@ -1132,10 +1141,13 @@ attack_network (struct scan_globals *globals)
           continue;
         }
 
+      connect_main_kb (&main_kb);
+      
       args.host = host;
       args.globals = globals;
       args.sched = sched;
       args.host_kb = host_kb;
+      args.main_kb = main_kb;
 
     forkagain:
       pid = create_process ((process_func_t) attack_start, &args);

--- a/src/attack.c
+++ b/src/attack.c
@@ -423,8 +423,9 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   openvas_signal (SIGUSR2, set_check_new_vhosts_flag);
   host_kb = kb;
   host_vhosts = vhosts;
-  kb_item_set_str (kb, "internal/ip", ip_str, 0);
   kb_item_set_int (kb, "internal/hostpid", getpid ());
+  host_set_time (main_kb, ip_str, "HOST_START");
+  kb_lnk_reset (main_kb);
   proctitle_set ("openvas: testing %s", ip_str);
   kb_lnk_reset (kb);
 
@@ -523,6 +524,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
 host_died:
   pluginlaunch_stop ();
   plugins_scheduler_free (sched);
+  host_set_time (main_kb, ip_str, "HOST_END");
 }
 
 /*

--- a/src/attack.c
+++ b/src/attack.c
@@ -1122,7 +1122,8 @@ attack_network (struct scan_globals *globals)
       while (1);
 
       host_str = gvm_host_value_str (host);
-      if (hosts_new (host_str, host_kb) < 0)
+      connect_main_kb (&main_kb);
+      if (hosts_new (host_str, host_kb, main_kb) < 0)
         {
           kb_delete (host_kb);
           g_free (host_str);
@@ -1135,8 +1136,6 @@ attack_network (struct scan_globals *globals)
           g_free (host_str);
           continue;
         }
-
-      connect_main_kb (&main_kb);
       
       args.host = host;
       args.globals = globals;

--- a/src/attack.c
+++ b/src/attack.c
@@ -158,7 +158,6 @@ static int
 comm_send_status (kb_t kb, char *hostname, int curr, int max)
 {
   char buffer[2048];
-  char key[64];
 
   if (!hostname || !kb)
     return -1;
@@ -166,9 +165,8 @@ comm_send_status (kb_t kb, char *hostname, int curr, int max)
   if (strlen (hostname) > (sizeof (buffer) - 50))
     return -1;
 
-  snprintf (buffer, sizeof (buffer), "%d/%d", curr, max);
-  snprintf (key, sizeof (buffer), "internal/status/%s", hostname);
-  kb_item_push_str (kb, key, buffer);
+  snprintf (buffer, sizeof (buffer), "%s/%d/%d", hostname, curr, max);
+  kb_item_push_str (kb, "internal/status", buffer);
 
   return 0;
 }
@@ -178,19 +176,10 @@ error_message_to_client2 (kb_t kb, const char *msg, const char *ip_str,
                           const char *port)
 {
   char buf[2048];
-  char key[64];
-  char *ipstr;
 
-  if (ip_str)
-    ipstr = g_strdup(ip_str);
-  else
-    ipstr = g_strdup("");
-
-  sprintf (buf, "ERRMSG|||%s|||%s|||%s||| |||%s", ipstr, ipstr, port ?: " ",
-           msg ?: "No error.");
-  sprintf (key, "internal/results%s%s", ip_str ?"/": "", ipstr);
-  kb_item_push_str (kb, key, buf);
-  g_free(ipstr);
+  sprintf (buf, "ERRMSG|||%s|||%s|||%s||| |||%s", ip_str ?: "", ip_str ?: "",
+           port ?: " ", msg ?: "No error.");
+  kb_item_push_str (kb, "internal/results", buf);
 }
 
 static void
@@ -472,9 +461,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
               if (e == ERR_HOST_DEAD)
                 {
                   char buffer[2048];
-                  char key[64];
 
-                  sprintf (key, "internal/results/%s", ip_str);
                   snprintf (
                     buffer, sizeof (buffer),
                     "LOG|||%s||| |||general/Host_Details||| |||<host><detail>"
@@ -487,7 +474,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                      calculate the scan progress. */
                   comm_send_status (main_kb, ip_str, 0, -1);
 #endif
-                  kb_item_push_str (kb, key, buffer);
+                  kb_item_push_str (kb, "internal/results", buffer);
                   goto host_died;
                 }
               else if (e == ERR_CANT_FORK)

--- a/src/attack.c
+++ b/src/attack.c
@@ -649,7 +649,8 @@ attack_start (struct attack_start_args *args)
         error_message_to_client2 (main_kb, "Host access denied.", ip_str, NULL);
       else
         error_message_to_client2 (
-          main_kb, "Host access denied (system-wide restriction.)", ip_str, NULL);
+          main_kb, "Host access denied (system-wide restriction.)", ip_str,
+          NULL);
 
       kb_item_set_str (kb, "internal/host_deny", "True", 0);
       g_warning ("Host %s access denied.", ip_str);
@@ -1136,7 +1137,7 @@ attack_network (struct scan_globals *globals)
           g_free (host_str);
           continue;
         }
-      
+
       args.host = host;
       args.globals = globals;
       args.sched = sched;

--- a/src/attack.c
+++ b/src/attack.c
@@ -179,11 +179,18 @@ error_message_to_client2 (kb_t kb, const char *msg, const char *ip_str,
 {
   char buf[2048];
   char key[64];
-  
-  sprintf (buf, "ERRMSG|||%s|||%s||| |||%s", ip_str ?: "", port ?: " ",
+  char *ipstr;
+
+  if (ip_str)
+    ipstr = g_strdup(ip_str);
+  else
+    ipstr = g_strdup("");
+
+  sprintf (buf, "ERRMSG|||%s|||%s|||%s||| |||%s", ipstr, ipstr, port ?: " ",
            msg ?: "No error.");
-  sprintf (key, "internal/results%s%s", ip_str ?"/": "", ip_str ?: "");
+  sprintf (key, "internal/results%s%s", ip_str ?"/": "", ipstr);
   kb_item_push_str (kb, key, buf);
+  g_free(ipstr);
 }
 
 static void
@@ -470,9 +477,10 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                   sprintf (key, "internal/results/%s", ip_str);
                   snprintf (
                     buffer, sizeof (buffer),
-                    "LOG||| |||general/Host_Details||| |||<host><detail>"
+                    "LOG|||%s||| |||general/Host_Details||| |||<host><detail>"
                     "<name>Host dead</name><value>1</value><source>"
-                    "<description/><type/><name/></source></detail></host>");
+                    "<description/><type/><name/></source></detail></host>",
+                    ip_str);
 #if (PROGRESS_BAR_STYLE == 1)
                   /* In case of a dead host, it sends max_ports = -1 to the
                      manager. The host will not be taken into account to

--- a/src/attack_tests.c
+++ b/src/attack_tests.c
@@ -96,7 +96,7 @@ Ensure (attack, comm_send_status_sends_correct_text)
   expect (__wrap_redis_push_str);
   assert_that (comm_send_status (kb, "127.0.0.1", 11, 67), is_equal_to (0));
   assert_that (strcmp (given_name, "internal/status"), is_equal_to (0));
-  assert_that (strcmp (given_value, "11/67"), is_equal_to (0));
+  assert_that (strcmp (given_value, "127.0.0.1/11/67"), is_equal_to (0));
 
   g_free (given_name);
   g_free (given_value);

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -110,6 +110,7 @@ host_rm (struct host *h)
     {
       kb_delete (h->host_kb);
       h->host_kb = NULL;
+      kb_lnk_reset (h->results_kb);
     }
 
   g_free (h->name);

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -98,17 +98,7 @@ host_rm (struct host *h)
   if (h->pid != 0)
     waitpid (h->pid, NULL, WNOHANG);
 
-  if (!global_scan_stop)
-    {
-      char key[1024];
-      char *scan_id = kb_item_get_str (h->host_kb, "internal/scan_id");
-      snprintf (key, sizeof (key), "internal/%s", scan_id);
-      kb_item_set_str (h->host_kb, key, "finished", 0);
-
-      host_set_time (h->results_kb, h->ip, "HOST_END");
-      kb_lnk_reset (h->host_kb);
-      g_free (scan_id);
-    }
+  host_set_time (h->results_kb, h->ip, "HOST_END");
 
   if (h->next != NULL)
     h->next->prev = h->prev;
@@ -116,7 +106,7 @@ host_rm (struct host *h)
   if (h->prev != NULL)
     h->prev->next = h->next;
 
-  if (global_scan_stop == 1 && h->host_kb)
+  if (h->host_kb)
     {
       kb_delete (h->host_kb);
       h->host_kb = NULL;

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -85,8 +85,8 @@ host_set_time (kb_t kb, char *ip, char *type)
   if (timestr[len - 1] == '\n')
     timestr[len - 1] = '\0';
 
-  snprintf (log_msg, sizeof (log_msg),
-           "%s|||%s||||||||| |||%s", type, ip, timestr);
+  snprintf (log_msg, sizeof (log_msg), "%s|||%s||||||||| |||%s", type, ip,
+            timestr);
   g_free (timestr);
 
   kb_item_push_str (kb, "internal/results", log_msg);

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -32,7 +32,7 @@ int
 hosts_init (int);
 
 int
-hosts_new (char *, kb_t);
+hosts_new (char *, kb_t, kb_t);
 
 int
 hosts_set_pid (char *, pid_t);

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -43,4 +43,6 @@ hosts_read (void);
 void
 hosts_stop_all (void);
 
+void
+host_set_time (kb_t, char *, char *);
 #endif

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -149,7 +149,7 @@ nasl_thread (struct script_infos *);
  */
 int
 nasl_plugin_launch (struct scan_globals *globals, struct in6_addr *ip,
-                    GSList *vhosts, kb_t kb, const char *oid)
+                    GSList *vhosts, kb_t kb, kb_t main_kb, const char *oid)
 {
   int module;
   struct script_infos infos;
@@ -159,6 +159,7 @@ nasl_plugin_launch (struct scan_globals *globals, struct in6_addr *ip,
   infos.vhosts = vhosts;
   infos.globals = globals;
   infos.key = kb;
+  infos.results = main_kb;
   infos.oid = (char *) oid;
   infos.name = nvticache_get_src (oid);
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -107,7 +107,7 @@ update_running_processes (kb_t kb)
               if (is_alive)
                 {
                   char msg[2048];
-                  
+
                   if (log_whole)
                     g_message ("%s (pid %d) is slow to finish - killing it",
                                oid, processes[i].pid);
@@ -342,7 +342,8 @@ plugin_timeout (nvti_t *nvti)
  */
 int
 plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
-               struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb, nvti_t *nvti)
+               struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb,
+               nvti_t *nvti)
 {
   int p;
 
@@ -354,7 +355,8 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   processes[p].plugin = plugin;
   processes[p].timeout = plugin_timeout (nvti);
   gettimeofday (&(processes[p].start), NULL);
-  processes[p].pid = nasl_plugin_launch (globals, ip, vhosts, kb, main_kb, plugin->oid);
+  processes[p].pid =
+    nasl_plugin_launch (globals, ip, vhosts, kb, main_kb, plugin->oid);
 
   if (processes[p].pid > 0)
     num_running_processes++;

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -107,7 +107,6 @@ update_running_processes (kb_t kb)
               if (is_alive)
                 {
                   char msg[2048];
-                  char key[64];
                   
                   if (log_whole)
                     g_message ("%s (pid %d) is slow to finish - killing it",
@@ -118,8 +117,7 @@ update_running_processes (kb_t kb)
                            "NVT timed out after %d seconds.",
                            hostname, oid ?: " ", processes[i].timeout);
 
-                  sprintf (key, "internal/results/%s", hostname);
-                  kb_item_push_str (kb, key, msg);
+                  kb_item_push_str (kb, "internal/results", msg);
 
                   ret_terminate = terminate_process (processes[i].pid);
                   if (ret_terminate == 0)

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -114,9 +114,9 @@ update_running_processes (kb_t kb)
                                oid, processes[i].pid);
 
                   sprintf (msg,
-                           "ERRMSG||| |||general/tcp|||%s|||"
+                           "ERRMSG|||%s||| |||general/tcp|||%s|||"
                            "NVT timed out after %d seconds.",
-                           oid ?: " ", processes[i].timeout);
+                           hostname, oid ?: " ", processes[i].timeout);
 
                   sprintf (key, "internal/results/%s", hostname);
                   kb_item_push_str (kb, key, msg);

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -39,7 +39,7 @@ pluginlaunch_stop (void);
 
 int
 plugin_launch (struct scan_globals *, struct scheduler_plugin *,
-               struct in6_addr *, GSList *, kb_t, nvti_t *);
+               struct in6_addr *, GSList *, kb_t, kb_t, nvti_t *);
 
 void
 pluginlaunch_disable_parallel_checks (void);

--- a/src/pluginload.h
+++ b/src/pluginload.h
@@ -55,6 +55,6 @@ nasl_plugin_add (char *, char *);
 
 int
 nasl_plugin_launch (struct scan_globals *, struct in6_addr *, GSList *, kb_t,
-                    const char *);
+                    kb_t, const char *);
 
 #endif


### PR DESCRIPTION
Also progress status and start_time and end_time messages are stored in the main kb.
This allows openvas to release the host kb when the host scan finishes.
The results stored in internal/results and internal/status keys in the main task DB, include now the host ip address.

