### PR TITLE
Make the output of the NASL dump_* packet forgery functions consistent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use flock to lock the feed lock file. [#507](https://github.com/greenbone/openvas/pull/507)
 - Move alive detection module (Boreas) into gvm-libs [#519](https://github.com/greenbone/openvas/pull/519)
 - Allow to set all legal types of icmp v6 in icmp header in openvas-nasl. [#542](https://github.com/greenbone/openvas/pull/542)
+- The output of the NASL dump_* packet forgery functions was made consistent. [#555](https://github.com/greenbone/openvas/pull/555)
 
 ### Fixed
 - Improve signal handling when update vhosts list. [#425](https://github.com/greenbone/openvas/pull/425)

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -379,31 +379,31 @@ dump_ip_packet (lex_ctxt *lexic)
       else
         {
           printf ("------\n");
-          printf ("\tip_hl : %d\n", ip->ip_hl);
-          printf ("\tip_v  : %d\n", ip->ip_v);
-          printf ("\tip_tos: %d\n", ip->ip_tos);
-          printf ("\tip_len: %d\n", UNFIX (ip->ip_len));
-          printf ("\tip_id : %d\n", ntohs (ip->ip_id));
-          printf ("\tip_off: %d\n", UNFIX (ip->ip_off));
-          printf ("\tip_ttl: %d\n", ip->ip_ttl);
+          printf ("\tip_hl  : %d\n", ip->ip_hl);
+          printf ("\tip_v   : %d\n", ip->ip_v);
+          printf ("\tip_tos : %d\n", ip->ip_tos);
+          printf ("\tip_len : %d\n", UNFIX (ip->ip_len));
+          printf ("\tip_id  : %d\n", ntohs (ip->ip_id));
+          printf ("\tip_off : %d\n", UNFIX (ip->ip_off));
+          printf ("\tip_ttl : %d\n", ip->ip_ttl);
           switch (ip->ip_p)
             {
             case IPPROTO_TCP:
-              printf ("\tip_p  : IPPROTO_TCP (%d)\n", ip->ip_p);
+              printf ("\tip_p   : IPPROTO_TCP (%d)\n", ip->ip_p);
               break;
             case IPPROTO_UDP:
-              printf ("\tip_p  : IPPROTO_UDP (%d)\n", ip->ip_p);
+              printf ("\tip_p   : IPPROTO_UDP (%d)\n", ip->ip_p);
               break;
             case IPPROTO_ICMP:
-              printf ("\tip_p  : IPPROTO_ICMP (%d)\n", ip->ip_p);
+              printf ("\tip_p   : IPPROTO_ICMP (%d)\n", ip->ip_p);
               break;
             default:
-              printf ("\tip_p  : %d\n", ip->ip_p);
+              printf ("\tip_p   : %d\n", ip->ip_p);
               break;
             }
-          printf ("\tip_sum: 0x%x\n", ntohs (ip->ip_sum));
-          printf ("\tip_src: %s\n", inet_ntoa (ip->ip_src));
-          printf ("\tip_dst: %s\n", inet_ntoa (ip->ip_dst));
+          printf ("\tip_sum : 0x%x\n", ntohs (ip->ip_sum));
+          printf ("\tip_src : %s\n", inet_ntoa (ip->ip_src));
+          printf ("\tip_dst : %s\n", inet_ntoa (ip->ip_dst));
           printf ("\n");
         }
     }

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -330,10 +330,10 @@ dump_ipv6_packet (lex_ctxt *lexic)
       else
         {
           printf ("------\n");
-          printf ("\tip6_v  : %d\n", ntohl (ip6->ip6_flow) >> 28);
-          printf ("\tip6_tc: %d\n", (ntohl (ip6->ip6_flow) >> 20) & 0xff);
-          printf ("\tip6_fl: %d\n", ntohl (ip6->ip6_flow) & 0x3ffff);
-          printf ("\tip6_plen: %d\n", UNFIX (ip6->ip6_plen));
+          printf ("\tip6_v    : %d\n", ntohl (ip6->ip6_flow) >> 28);
+          printf ("\tip6_tc   : %d\n", (ntohl (ip6->ip6_flow) >> 20) & 0xff);
+          printf ("\tip6_fl   : %d\n", ntohl (ip6->ip6_flow) & 0x3ffff);
+          printf ("\tip6_plen : %d\n", UNFIX (ip6->ip6_plen));
           printf ("\tip6_hlim : %d\n", ip6->ip6_hlim);
           switch (ip6->ip6_nxt)
             {
@@ -350,9 +350,9 @@ dump_ipv6_packet (lex_ctxt *lexic)
               printf ("\tip6_nxt  : %d\n", ip6->ip6_nxt);
               break;
             }
-          printf ("\tip6_src: %s\n",
+          printf ("\tip6_src  : %s\n",
                   inet_ntop (AF_INET6, &ip6->ip6_src, addr, sizeof (addr)));
-          printf ("\tip6_dst: %s\n",
+          printf ("\tip6_dst  : %s\n",
                   inet_ntop (AF_INET6, &ip6->ip6_dst, addr, sizeof (addr)));
           printf ("\n");
         }


### PR DESCRIPTION
### IPv4

Output before this PR:

```
------
	ip_hl : 5
	ip_v  : 4
	ip_tos: 0
	ip_len: 40
	ip_id : 64776
	ip_off: 0
	ip_ttl: 63
	ip_p  : IPPROTO_TCP (6)
	ip_sum: 0xf064
	ip_src: xxx
	ip_dst: xxx

------
	th_sport : 40508
	th_dport : 40509
	th_seq   : 0
	th_ack   : 1182458317
	th_x2    : 0
	th_off   : 5
	th_flags : TH_RST|TH_ACK (20)
	th_win   : 0
	th_sum   : 0xc89f
	th_urp   : 0
	Data     : 
```

Output after this PR:

```
------
	ip_hl  : 5
	ip_v   : 4
	ip_tos : 0
	ip_len : 40
	ip_id  : 40224
	ip_off : 0
	ip_ttl : 63
	ip_p   : IPPROTO_TCP (6)
	ip_sum : 0xd8c4
	ip_src : xxx
	ip_dst : xxx

------
	th_sport : 40508
	th_dport : 40509
	th_seq   : 0
	th_ack   : 208730020
	th_x2    : 0
	th_off   : 5
	th_flags : TH_RST|TH_ACK (20)
	th_win   : 0
	th_sum   : 0xecd2
	th_urp   : 0
	Data     : 
```

### IPv6

Output before this PR:

```
------
	ip6_v  : 6
	ip6_tc: 0
	ip6_fl: 0
	ip6_plen: 20
	ip6_hlim : 255
	ip6_nxt  : IPPROTO_TCP (6)
	ip6_src: xxx
	ip6_dst: xxx

------
	th_sport : 40508
	th_dport : 40509
	th_seq   : 0
	th_ack   : 871074376
	th_x2    : 0
	th_off   : 5
	th_flags : TH_RST|TH_ACK (20)
	th_win   : 0
	th_sum   : 0x65cb
	th_urp   : 0
	Data     : 
```

Output after this PR:

```
------
	ip6_v    : 6
	ip6_tc   : 0
	ip6_fl   : 0
	ip6_plen : 20
	ip6_hlim : 255
	ip6_nxt  : IPPROTO_TCP (6)
	ip6_src  : xxx
	ip6_dst  : xxx

------
	th_sport : 40508
	th_dport : 40509
	th_seq   : 0
	th_ack   : 1210927891
	th_x2    : 0
	th_off   : 5
	th_flags : TH_RST|TH_ACK (20)
	th_win   : 0
	th_sum   : 0x6e1e
	th_urp   : 0
	Data     :
```