### PR TITLE
Add a missing space to a log message.

### DIFF
--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -401,7 +401,7 @@ mark_sphinxql (struct script_infos *desc, int port)
 {
   register_service (desc, port, "sphinxql");
   post_log (oid, desc, port,
-            "A Sphinx search server (MySQL listener)"
+            "A Sphinx search server (MySQL listener) "
             "seems to be running on this port");
 }
 


### PR DESCRIPTION
Minor improvement for #387 as the log message was showing up like the following without a space:

```
A Sphinx search server (MySQL listener)seems to be running on this port
```