### PR TITLE
Allow group access to lockfile and fix empty timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix byte ordering and wrong PROTO identifier in dump_ipv6_packet() for openvas-nasl. [#549](https://github.com/greenbone/openvas/pull/549)
 - Fix size calculation which lead to alloc error in get_tcp_element() of openvas-nasl. [#546](https://github.com/greenbone/openvas/pull/546)
 - Fix filter out of default 'radio' type preferences [#560](https://github.com/greenbone/openvas/pull/560)
+- Allow group access to lockfile and fix empty timestamp [#562](https://github.com/greenbone/openvas/pull/562)
 
 ### Removed
 - Removed "network scan" mode. This includes removal of NASL API methods "scan_phase()" and "network_targets()". Sending a "network_mode=yes" in a scanner configuration will have no effect anymore. [#493](https://github.com/greenbone/openvas/pull/493)

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -512,7 +512,7 @@ do_sync ()
       date > $OPENVAS_RUN_DIR/feed-update.lock
       sync_nvts
       echo -n $OPENVAS_RUN_DIR/feed-update.lock
-    )9<$OPENVAS_RUN_DIR/feed-update.lock
+    )9>>$OPENVAS_RUN_DIR/feed-update.lock
   fi
 }
 

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -512,7 +512,7 @@ do_sync ()
       date > $OPENVAS_RUN_DIR/feed-update.lock
       sync_nvts
       echo -n $OPENVAS_RUN_DIR/feed-update.lock
-    )9>$OPENVAS_RUN_DIR/feed-update.lock
+    )9<$OPENVAS_RUN_DIR/feed-update.lock
   fi
 }
 

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -503,6 +503,7 @@ do_sync ()
     log_write "Feed is already current, skipping synchronization."
   else
     (
+      chmod +660 $OPENVAS_RUN_DIR/feed-update.lock
       flock -n 9
       if [ $? -eq 1 ] ; then
           log_warning "Another process related to the feed update is already running"


### PR DESCRIPTION
This allows gvmd and ospd-openvas to be run as different users in the same group and stops the timestamp in the lockfile being cleared when it is already locked.