### PR TITLE
Fix syntax of openvas manpage.

### DIFF
--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -221,20 +221,17 @@ The canonical places where you will find more information
 about OpenVAS are: 
 
 .RS
-.UR
-https://community.greenbone.net
+.UR https://community.greenbone.net
+Community site
 .UE
-(Community site)
 .br
-.UR
-https://github.com/greenbone/
+.UR https://github.com/greenbone
+Development site
 .UE
-(Development site)
 .br
-.UR
-https://www.openvas.org/
+.UR https://www.openvas.org
+Traditional home site
 .UE
-(Traditional home site)
 .RE
 	
 .SH AUTHORS


### PR DESCRIPTION
Previous to this change the man page related part looked like this:

```
              https://community.greenbone.net ⟨⟩ (Community site)
              https://github.com/greenbone/ ⟨⟩ (Development site)
              https://www.openvas.org/ ⟨⟩ (Traditional home site)
```

Now it is using the correct syntax as explained in https://man7.org/linux/man-pages/man7/man.7.html and is showing up like:

```
              Community site ⟨https://community.greenbone.net⟩
              Development site ⟨https://github.com/greenbone⟩
              Traditional home site ⟨https://www.openvas.org⟩
```

The final manpage can be verified with something like e.g.:

```
man doc/openvas.8.in
```