### PR TITLE
[7.0] Fix syntax of openvas manpage.

### DIFF
--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -218,20 +218,17 @@ The canonical places where you will find more information
 about OpenVAS are: 
 
 .RS
-.UR
-https://community.greenbone.net
+.UR https://community.greenbone.net
+Community site
 .UE
-(Community site)
 .br
-.UR
-https://github.com/greenbone/
+.UR https://github.com/greenbone
+Development site
 .UE
-(Development site)
 .br
-.UR
-https://www.openvas.org/
+.UR https://www.openvas.org
+Traditional home site
 .UE
-(Traditional home site)
 .RE
 	
 .SH AUTHORS


### PR DESCRIPTION
Backport of #569 to the openvas-7.0 branch.

Related: #570 