### PR TITLE
[6.0] Fix syntax of openvas manpage.

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -215,20 +215,17 @@ The canonical places where you will find more information
 about the OpenVAS Scanner are: 
 
 .RS
-.UR
-https://community.greenbone.net
+.UR https://community.greenbone.net
+Community site
 .UE
-(Community site)
 .br
-.UR
-https://github.com/greenbone/
+.UR https://github.com/greenbone
+Development site
 .UE
-(Development site)
 .br
-.UR
-https://www.openvas.org/
+.UR https://www.openvas.org
+Traditional home site
 .UE
-(Traditional home site)
 .RE
 	
 .SH AUTHORS


### PR DESCRIPTION
Backport of #569 to the openvas-scanner-6.0 branch

Related: #570 