### PR TITLE
Fork vhosts before creating the socket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20.08.1] (unreleased)
+
+### Fixed
+- Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)
+
+[20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
+
 ## [20.08] (2020-08-11)
 
 ### Added

--- a/misc/network.c
+++ b/misc/network.c
@@ -901,6 +901,11 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
   char *passwd = NULL;
   char *cafile = NULL;
   char *hostname = NULL;
+  char *hostname_aux = NULL;
+
+  /* Because plug_get_host_fqdn() forks for each vhost, we fork() before
+     creating the socket */
+  hostname_aux = plug_get_host_fqdn (args);
 
   if (!priority)
     priority = ""; /* To us an empty string is equivalent to NULL.  */
@@ -930,11 +935,16 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
                  " layer %d passed by %s",
                  transport, args->name);
       errno = EINVAL;
+
+      g_free (hostname_aux);
       return -1;
     }
 
   if ((fd = get_connection_fd ()) < 0)
-    return -1;
+    {
+      g_free (hostname_aux);
+      return -1;
+    }
   fp = OVAS_CONNECTION_FROM_FD (fd);
 
   fp->transport = transport;
@@ -977,9 +987,9 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
       /* We do not need a client certificate in this case */
       snprintf (buf, sizeof (buf), "Host/SNI/%d/force_disable", fp->port);
       if (kb_item_get_int (kb, buf) <= 0)
-        hostname = plug_get_host_fqdn (args);
+        hostname = hostname_aux;
+
       ret = open_SSL_connection (fp, cert, key, passwd, cafile, hostname);
-      g_free (hostname);
       g_free (cert);
       g_free (key);
       g_free (passwd);
@@ -988,6 +998,8 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
         goto failed;
       break;
     }
+
+  g_free (hostname_aux);
 
   return fd;
 


### PR DESCRIPTION
This solves the issue in which a parent process creates a socket
and child processes inheritates the socket but are not allow to use it.
Now, each child uses its own socket.