### PR TITLE
Fork vhosts before creating the socket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [7.0.2] (unreleased)
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)
+
+### Removed
+
+[7.0.2]: https://github.com/greenbone/openvas/compare/v7.0.1...openvas-7.0
+
 ## [7.0.1] (2020-05-12)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)
+- Fork vhosts before creating the socket.[#579](https://github.com/greenbone/openvas/pull/579)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fork vhosts before creating the socket.[#579](https://github.com/greenbone/openvas/pull/579)
+- Fork vhosts before creating the socket. [#579](https://github.com/greenbone/openvas/pull/579)
 
 ### Removed
 

--- a/misc/network.c
+++ b/misc/network.c
@@ -893,6 +893,11 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
   char *passwd = NULL;
   char *cafile = NULL;
   char *hostname = NULL;
+  char *hostname_aux = NULL;
+
+  /* Because plug_get_host_fqdn() forks for each vhost, we fork() before
+     creating the socket */
+  hostname_aux = plug_get_host_fqdn (args);
 
   if (!priority)
     priority = ""; /* To us an empty string is equivalent to NULL.  */
@@ -922,11 +927,16 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
                  " layer %d passed by %s",
                  transport, args->name);
       errno = EINVAL;
+
+      g_free (hostname_aux);
       return -1;
     }
 
   if ((fd = get_connection_fd ()) < 0)
-    return -1;
+    {
+      g_free (hostname_aux);
+      return -1;
+    }
   fp = OVAS_CONNECTION_FROM_FD (fd);
 
   fp->transport = transport;
@@ -969,9 +979,9 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
       /* We do not need a client certificate in this case */
       snprintf (buf, sizeof (buf), "Host/SNI/%d/force_disable", fp->port);
       if (kb_item_get_int (kb, buf) <= 0)
-        hostname = plug_get_host_fqdn (args);
+        hostname = hostname_aux;
+
       ret = open_SSL_connection (fp, cert, key, passwd, cafile, hostname);
-      g_free (hostname);
       g_free (cert);
       g_free (key);
       g_free (passwd);
@@ -980,6 +990,8 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
         goto failed;
       break;
     }
+
+  g_free (hostname_aux);
 
   return fd;
 


### PR DESCRIPTION
This solves the issue in which a parent process creates a socket
and child processes inheritates the socket but are not allow to use it.
Now, each child uses its own socket.

Backport of #576 to the openvas-7.0 branch.