### PR TITLE
Fix comparison link in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - Drop HTTP sync [#489](https://github.com/greenbone/openvas/pull/489)
 
-[7.0.1]: https://github.com/greenbone/openvas/compare/v7.0.1...v7.0.0
+[7.0.1]: https://github.com/greenbone/openvas/compare/v7.0.0...v7.0.1
 
 ## [7.0.0] (2019-10-11)
 


### PR DESCRIPTION
The lower release / older branch needs to be on the left side of the link.