### PR TITLE
Check if another forked child has already added the vhost.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)
+- Check if another forked child has already added the same vhost. [#581](https://github.com/greenbone/openvas/pull/581)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -289,7 +289,6 @@ check_new_vhosts (void)
   if (!current_vhosts)
     {
       unset_check_new_vhosts_flag ();
-      g_message ("no current vhosts");
       return;
     }
   while (current_vhosts)

--- a/src/attack.c
+++ b/src/attack.c
@@ -278,23 +278,55 @@ unset_check_new_vhosts_flag (void)
 static void
 check_new_vhosts (void)
 {
-  char *value;
+  struct kb_item *current_vhosts = NULL;
 
   if (get_check_new_vhosts_flag () == 0)
     return;
 
-  while ((value = kb_item_pop_str (host_kb, "internal/vhosts")))
+  /* Check for duplicate vhost value already added by other forked child of the
+   * same plugin. */
+  current_vhosts = kb_item_get_all (host_kb, "internal/vhosts");
+  if (!current_vhosts)
     {
-      /* Get the source. */
-      char buffer[4096], *source;
+      unset_check_new_vhosts_flag ();
+      g_message ("no current vhosts");
+      return;
+    }
+  while (current_vhosts)
+    {
+      GSList *vhosts = NULL;
+      char buffer[4096], *source, *value;
       gvm_vhost_t *vhost;
 
+      value = g_strdup (current_vhosts->v_str);
+
+      /* Check for duplicate vhost value in args. */
+      vhosts = host_vhosts;
+      while (vhosts)
+        {
+          gvm_vhost_t *tmp = vhosts->data;
+
+          if (!strcmp (tmp->value, value))
+            {
+              g_warning ("%s: Value '%s' exists already", __func__, value);
+              unset_check_new_vhosts_flag ();
+              kb_item_free (current_vhosts);
+              return;
+            }
+          vhosts = vhosts->next;
+        }
+
+      /* Get sources*/
       g_snprintf (buffer, sizeof (buffer), "internal/source/%s", value);
-      source = kb_item_pop_str (host_kb, buffer);
+      source = kb_item_get_str (host_kb, buffer);
       assert (source);
       vhost = gvm_vhost_new (value, source);
       host_vhosts = g_slist_append (host_vhosts, vhost);
+
+      current_vhosts = current_vhosts->next;
     }
+
+  kb_item_free (current_vhosts);
   unset_check_new_vhosts_flag ();
 }
 


### PR DESCRIPTION
In some cases, in which expand_vhosts and test_empty_vhost options
are enabled, a plugin process fork()s one child for vhost.
These children inherit the current state of vhosts list, but it does not
check if the concurrent child plugin has already added a new found vhost.
Now, it checks not only if the vhost has been added by another plugin before
(and already exists in the vhosts list), but also checks if a concurrent child
added to the internal/vhosts key in redis.