### PR TITLE
[7.0] Fix typo in comment.

### DIFF
--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -136,7 +136,7 @@ stderr_write ()
 }
 
 # Read the general information about the feed origin from
-# the file "plugin_feed_infoc.inc" inside the feed directory.
+# the file "plugin_feed_info.inc" inside the feed directory.
 get_feed_info ()
 {
   INFOFILE="$NVT_DIR/plugin_feed_info.inc"


### PR DESCRIPTION
Not much to say besides that the typo is already gone in the 20.08 branch.