### PR TITLE
Send duplicated hosts as dead hosts to ospd, to adjust scan progress calculation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-20.08
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -31,7 +31,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-20.08
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs
@@ -47,7 +47,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-20.08
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)
 - Check if another forked child has already added the same vhost. [#581](https://github.com/greenbone/openvas/pull/581)
+- Send duplicated hosts as dead hosts to ospd, to adjust scan progress calculation. [#586](https://github.com/greenbone/openvas/pull/586)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -996,6 +996,7 @@ attack_network (struct scan_globals *globals)
   const gchar *port_range;
   kb_t host_kb;
   GSList *unresolved;
+  int duplicated_hosts;
 
   gboolean test_alive_hosts_only = prefs_get_bool ("test_alive_hosts_only");
   gvm_hosts_t *alive_hosts_list = NULL;
@@ -1064,6 +1065,15 @@ attack_network (struct scan_globals *globals)
 
   hosts = gvm_hosts_new (hostlist);
   unresolved = gvm_hosts_resolve (hosts);
+
+  /* Duplicated hosts are removed from the list and ospd-openvas
+     needs to know that less hosts will be scanned, for the scan progress
+     calculation. Sent the amount of duplicated hosts as dead hosts to not
+     be taken in account. */
+  duplicated_hosts = gvm_hosts_duplicated (hosts);
+  if (duplicated_hosts > 0)
+    send_dead_hosts_to_ospd_openvas (duplicated_hosts);
+
   while (unresolved)
     {
       g_warning ("Couldn't resolve hostname '%s'", (char *) unresolved->data);


### PR DESCRIPTION
Duplicated hosts are removed from the list and ospd-openvas
needs to know that less hosts will be scanned, for the scan progress
calculation. Sent the amount of duplicated hosts as dead hosts to not
be taken in account.


Depends on PR greenbone/gvm-libs#387