### PR TITLE
Add support for TLSv1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: clang-format -i -style=file src/*.{c,h} misc/*.{c,h} nasl/*.{c,h} && git diff --exit-code
   test_units:
     docker:
-      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-gcc-core
+      - image: greenbone/build-env-openvas-scanner-master-debian-buster-gcc-core
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -26,7 +26,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test
   build_gcc_core:
     docker:
-      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-gcc-core
+      - image: greenbone/build-env-openvas-scanner-master-debian-buster-gcc-core
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -42,7 +42,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install
   scan_build:
     docker:
-      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-clang-core
+      - image: greenbone/build-env-openvas-scanner-master-debian-buster-clang-core
     steps:
       - run:
           working_directory: ~/gvm-libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Extend nasl lint to detect if function parameter is used twice. [#590](https://github.com/greenbone/openvas/pull/590)
+- Add support for TLSv1.3. [#588](https://github.com/greenbone/openvas/pull/588)
 
 ### Fixed
 - Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)

--- a/misc/network.c
+++ b/misc/network.c
@@ -422,6 +422,9 @@ set_gnutls_protocol (gnutls_session_t session, openvas_encaps_t encaps,
     case OPENVAS_ENCAPS_TLSv12:
       priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2:+ARCFOUR-128:%COMPAT";
       break;
+    case OPENVAS_ENCAPS_TLSv13:
+      priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3:%COMPAT";
+      break;
     case OPENVAS_ENCAPS_SSLv23: /* Compatibility mode */
       priorities =
         "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0:+ARCFOUR-128:%COMPAT";
@@ -799,6 +802,8 @@ socket_get_ssl_version (int fd)
       return OPENVAS_ENCAPS_TLSv11;
     case GNUTLS_TLS1_2:
       return OPENVAS_ENCAPS_TLSv12;
+    case GNUTLS_TLS1_3:
+      return OPENVAS_ENCAPS_TLSv13;
     default:
       return -1;
     }
@@ -926,6 +931,7 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
     case OPENVAS_ENCAPS_TLSv1:
     case OPENVAS_ENCAPS_TLSv11:
     case OPENVAS_ENCAPS_TLSv12:
+    case OPENVAS_ENCAPS_TLSv13:
     case OPENVAS_ENCAPS_TLScustom:
     case OPENVAS_ENCAPS_SSLv2:
       break;
@@ -974,6 +980,7 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
     case OPENVAS_ENCAPS_TLSv1:
     case OPENVAS_ENCAPS_TLSv11:
     case OPENVAS_ENCAPS_TLSv12:
+    case OPENVAS_ENCAPS_TLSv13:
     case OPENVAS_ENCAPS_TLScustom:
       cert = kb_item_get_str (kb, "SSL/cert");
       key = kb_item_get_str (kb, "SSL/key");
@@ -1154,6 +1161,7 @@ read_stream_connection_unbuffered (int fd, void *buf0, int min_len, int max_len)
     case OPENVAS_ENCAPS_TLSv1:
     case OPENVAS_ENCAPS_TLSv11:
     case OPENVAS_ENCAPS_TLSv12:
+    case OPENVAS_ENCAPS_TLSv13:
     case OPENVAS_ENCAPS_TLScustom:
       if (getpid () != fp->pid)
         {
@@ -1340,6 +1348,7 @@ write_stream_connection4 (int fd, void *buf0, int n, int i_opt)
     case OPENVAS_ENCAPS_TLSv1:
     case OPENVAS_ENCAPS_TLSv11:
     case OPENVAS_ENCAPS_TLSv12:
+    case OPENVAS_ENCAPS_TLSv13:
     case OPENVAS_ENCAPS_TLScustom:
 
       /* i_opt ignored for SSL */
@@ -1584,6 +1593,8 @@ get_encaps_name (openvas_encaps_t code)
       return "TLSv11";
     case OPENVAS_ENCAPS_TLSv12:
       return "TLSv12";
+    case OPENVAS_ENCAPS_TLSv13:
+      return "TLSv13";
     case OPENVAS_ENCAPS_TLScustom:
       return "TLScustom";
     default:
@@ -1607,6 +1618,7 @@ get_encaps_through (openvas_encaps_t code)
     case OPENVAS_ENCAPS_TLSv1:
     case OPENVAS_ENCAPS_TLSv11:
     case OPENVAS_ENCAPS_TLSv12:
+    case OPENVAS_ENCAPS_TLSv13:
     case OPENVAS_ENCAPS_TLScustom:
       return " through SSL";
     default:

--- a/misc/network.h
+++ b/misc/network.h
@@ -49,6 +49,7 @@ typedef enum openvas_encaps
   OPENVAS_ENCAPS_TLSv1,
   OPENVAS_ENCAPS_TLSv11,
   OPENVAS_ENCAPS_TLSv12,
+  OPENVAS_ENCAPS_TLSv13,
   OPENVAS_ENCAPS_TLScustom, /* SSL/TLS using custom priorities.  */
   OPENVAS_ENCAPS_MAX,
 } openvas_encaps_t;

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -342,6 +342,7 @@ nasl_this_host_name (lex_ctxt *lexic)
  *          - @a ENCAPS_TLSv1  TLS version 1.0
  *          - @a ENCAPS_TLSv11 TLS version 1.1
  *          - @a ENCAPS_TLSv12 TLS version 1.2
+ *          - @a ENCAPS_TLSv13 TLS version 1.3
  *          - @a ENCAPS_TLScustom SSL or TLS with custom priorities
  *
  * @nasluparam


### PR DESCRIPTION
**What**:
Add support for TLSv1.3

**Why**:
GnuTLS 3.6.5+ has enabled TLS 1.3 by default.

<!-- Why are these changes necessary? -->

**How**:
 - create certs
openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes

- start web server forcing the usage of tls1_3 only
openssl s_server -tls1_3 -key key.pem -cert cert.pem -accept 44330 -www 

The new TLSv1.3 has the transport value 8 internally in openvas. So, for testing, both values will be used: 7 -> TLS_12 and 8 -> TLS_13

#### tls_13_test.nasl:
```
port = 44330;
if( ! soc = open_sock_tcp( port ) )
  exit( 0 );

soc = socket_negotiate_ssl( socket:soc, transport:8 );

if (! soc)
   {
     display("no socket");
     return;
   }
display("There is a socket");     
send( socket:soc, data:'GET / HTTP/1.0\r\n\r\n' );

display("Received !!!");     

res = recv( socket:soc, length:512 );
display("Show!!!");     
display( res );
display("Close!!");     
close( soc );
exit( 0 );
```

Execute the script twice, first with transport: 7 and then with transport:8 as argument in soclet_negotiate_ssl()

With transport 7, the communication fails.
```
$ sudo openvas-nasl -X -B -d -i /home/jnicola/install/var/lib/openvas/vts/scripts -t 127.0.0.1 tls_v13.nasl
lib  nasl-Message: 16:11:17.512: Transport set in nasl: 7
lib  misc-Message: 16:11:17.513: Function socket_negotiate_ssl called from tls_v13.nasl: SSL/TLS connection failed.
lib  nasl-Message: 16:11:17.513: no socket
lib  nasl-Message: 16:11:17.514: Transport set in nasl: 7
lib  misc-Message: 16:11:17.514: Function socket_negotiate_ssl called from tls_v13.nasl: SSL/TLS connection failed.
lib  nasl-Message: 16:11:17.514: no socket

``` 

 With transport 8, an answer is received from the openssl s_server.

```
jnicola@malleus:~/my_nasl$ sudo openvas-nasl -X -B -d -i /home/jnicola/install/var/lib/openvas/vts/scripts -t 127.0.0.1 tls_v13.nasl
lib  nasl-Message: 16:12:43.540: Transport set in nasl: 8
lib  nasl-Message: 16:12:43.543: There is a socket
lib  nasl-Message: 16:12:43.543: Recieved !!!
lib  nasl-Message: 16:12:43.585: Show!!!
lib  nasl-Message: 16:12:43.586: HTTP/1.0 200 ok
Content-type: text/html

<HTML><BODY BGCOLOR="#ffffff">
<pre>

s_server -tls1_3 -key key.pem -cert cert.pem -accept 44330 -www 
Secure Renegotiation IS NOT supported
Ciphers supported in s_server binary
TLSv1.3    :TLS_AES_256_GCM_SHA384    TLSv1.3    :TLS_CHACHA20_POLY1305_SHA256 
TLSv1.3    :TLS_AES_128_GCM_SHA256    TLSv1.2    :ECDHE-ECDSA-AES256-GCM-SHA384 
TLSv1.2    :ECDHE-RSA-AES256-GCM-SHA384 TLSv1.2    :DHE-RSA-AES256-GCM-SHA384 
TLSv1.2    :ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 
lib  nasl-Message: 16:12:43.586: Close!!
```

- [ ] Tests "N/A"
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
