### PR TITLE
Handle the stop scan out of the interruption rutine

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -208,10 +208,13 @@ fork_sleep (int n)
 }
 
 int global_scan_stop = 0;
+static void scan_stop_cleanup (void);
 
 static int
 scan_is_stopped (void)
 {
+  if (global_scan_stop == 1)
+    scan_stop_cleanup ();
   return global_scan_stop;
 }
 
@@ -937,10 +940,19 @@ ad_thread_joined (gboolean joined)
 static void
 handle_scan_stop_signal ()
 {
+  global_scan_stop = 1;
+}
+
+static void
+scan_stop_cleanup ()
+{
   kb_t main_kb = NULL;
   char *pid;
+  static int already_called = 0;
 
-  global_scan_stop = 1;
+  if (already_called == 1)
+    return;
+
   connect_main_kb (&main_kb);
   pid = kb_item_get_str (main_kb, ("internal/ovas_pid"));
   kb_lnk_reset (main_kb);
@@ -949,6 +961,7 @@ handle_scan_stop_signal ()
    * Else stop all running plugin processes for the current host fork. */
   if (atoi (pid) == getpid ())
     {
+      already_called = 1;
       hosts_stop_all ();
 
       /* Stop (cancel) alive detection if enabled and not already joined. */
@@ -974,6 +987,7 @@ handle_scan_stop_signal ()
         }
     }
   else
+    /* Current host process */
     pluginlaunch_stop ();
 
   g_free (pid);

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -202,7 +202,7 @@ hosts_stop_host (struct host *h)
   if (h == NULL)
     return -1;
 
-  g_message ("Stopping host %s scan", h->name);
+  g_message ("Stopping host %s scan (pid: %d)", h->name, h->pid);
   kill (h->pid, SIGUSR1);
   return 0;
 }


### PR DESCRIPTION
During interruption, just set a variable. This variable is checked later
and the main process does the cleanup if the scan stop signal was received.
Signal handlers must be lean. Malloc is a non-async-signal
funtion which can generates deadlocks if it is called from inside a signal handler.
Redis related functions (kb_item_get_str()) use malloc.
Therefore this avoid deadlock.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
During interruption, just set a variable. This variable is checked later
and the main process does the cleanup if the scan stop signal was received.


**Why**:

<!-- Why are these changes necessary? -->
Signal handlers must be lean. Malloc is a non-async-signal
funtion which can generates deadlocks if it is called from inside a signal handler.
Redis related functions (kb_item_get_str()) use malloc.
Therefore this avoid deadlock.

**How**:
Not always is reproducible a deadlock. But you can try starting and stopping a task.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
