### PR TITLE
Only send the signal if the pid is a positive value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)
 - Check if another forked child has already added the same vhost. [#581](https://github.com/greenbone/openvas/pull/581)
 - Send duplicated hosts as dead hosts to ospd, to adjust scan progress calculation. [#586](https://github.com/greenbone/openvas/pull/586)
+- Only send the signal if the pid is a positive value. [#593](https://github.com/greenbone/openvas/pull/593)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -408,6 +408,13 @@ stop_single_task_scan (void)
     exit (1);
 
   pid = kb_item_get_int (kb, "internal/ovas_pid");
+
+  /* Only send the signal if the pid is a positive value.
+     Since kb_item_get_int() will return -1 if the key does
+     not exist. killing with -1 pid will send the signal system wide.
+   */
+  if (pid <= 0)
+    return;
   kill (pid, SIGUSR1);
 
   exit (0);


### PR DESCRIPTION

**What**:
Only send the signal if the pid is a positive value.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Since kb_item_get_int() will return -1 if the key does
not exist. killing with -1 as pid will send the signal system wide.
Apparently the stop signal is received twice, being the second one
sent by a child process, but received after the kb was already cleaned up.
Therefore -1 is received and the kill SIGUSR1 signal reaches other process.
<!-- Why are these changes necessary? -->

**How**:
You can test this starting 2 or 3 parallel scans with many hosts. This produces a big amount child process which during stops scans, spread the kill signal to other process. You should be able to stop the scans without problem if this patch is applied.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
