### PR TITLE
Add alternative for supporting snmp during scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Extend nasl lint to detect if function parameter is used twice. [#590](https://github.com/greenbone/openvas/pull/590)
 - Add support for TLSv1.3. [#588](https://github.com/greenbone/openvas/pull/588)
+- Add alternative for supporting snmp during scans. [#594](https://github.com/greenbone/openvas/pull/594)
 
 ### Fixed
 - Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Recommended for extended Windows support (e.g. automatically start the remote re
 * impacket-wmiexec of python-impacket >= 0.9.15 found within your PATH
 
 Recommended to have improved SNMP support:
-* netsnmp
+* netsnmp libraries or alternatively the snmpget binary.
 
 Install prerequisites on Debian GNU/Linux 'Buster' 10:
 

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -287,9 +287,9 @@ static init_func libfuncs[] = {
   {"gzip", nasl_gzip},
   {"DES", nasl_cipher_des},
 
-#ifdef HAVE_NETSNMP
   {"snmpv1_get", nasl_snmpv1_get},
   {"snmpv2c_get", nasl_snmpv2c_get},
+#ifdef HAVE_NETSNMP
   {"snmpv3_get", nasl_snmpv3_get},
 #endif /* HAVE_NETSNMP */
 

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -286,13 +286,9 @@ static init_func libfuncs[] = {
   {"gunzip", nasl_gunzip},
   {"gzip", nasl_gzip},
   {"DES", nasl_cipher_des},
-
   {"snmpv1_get", nasl_snmpv1_get},
   {"snmpv2c_get", nasl_snmpv2c_get},
-#ifdef HAVE_NETSNMP
   {"snmpv3_get", nasl_snmpv3_get},
-#endif /* HAVE_NETSNMP */
-
   {"ssh_connect", nasl_ssh_connect},
   {"ssh_disconnect", nasl_ssh_disconnect},
   {"ssh_session_id_from_sock", nasl_ssh_session_id_from_sock},

--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -26,7 +26,12 @@
 #include "nasl_lex_ctxt.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <gvm/base/logging.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 /*
  * @brief Check that protocol value is valid.
@@ -299,11 +304,6 @@ nasl_snmpv3_get (lex_ctxt *lexic)
 
 #else
 
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
-
 #define SNMP_VERSION_1 0
 #define SNMP_VERSION_2c 1
 
@@ -319,14 +319,14 @@ parse_snmp_error (char **result)
 
   while (res_aux)
     {
-      /* There is no special reason, we return the whole error message 
+      /* There is no special reason, we return the whole error message
          but removing the new line char at the end.
        */
       if (*res_aux == NULL)
         {
           char *pos;
 
-          if ((pos=strchr(*result, '\n')) != NULL)
+          if ((pos = strchr (*result, '\n')) != NULL)
             *pos = '\0';
           break;
         }
@@ -391,7 +391,7 @@ static int
 snmpv1v2c_get (const char *peername, const char *community, const char *oid_str,
                int version, char **result)
 {
-  char *argv[7];
+  char *argv[7], *pos = NULL;
   GError *err = NULL;
   int sout = 0, serr = 0, ret;
 
@@ -441,6 +441,10 @@ snmpv1v2c_get (const char *peername, const char *community, const char *oid_str,
 
   check_spwan_output (sout, result);
   close (sout);
+
+  /* Remove new line char from the result */
+  if ((pos = strchr (*result, '\n')) != NULL)
+    *pos = '\0';
 
   return 0;
 }

--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -260,6 +260,11 @@ snmpv1v2c_get (const char *peername, const char *community, const char *oid_str,
 #define SNMP_VERSION_1 0
 #define SNMP_VERSION_2c 1
 
+/**
+ * @brief Parse the snmp error.
+ *
+ * @param result[in,out] The result error to be parsed.
+ */
 static void
 parse_snmp_error (char **result)
 {
@@ -299,6 +304,14 @@ parse_snmp_error (char **result)
   return;
 }
 
+/**
+ * @brief Read data from a file descriptor.
+ *
+ * @param fd[in] File descriptor to read from.
+ * @param result[out] String to write to.
+ *
+ * @return 0 success, -1 read error.
+ */
 static int
 check_spwan_output (int fd, char **result)
 {
@@ -329,7 +342,7 @@ check_spwan_output (int fd, char **result)
   return 0;
 }
 
-/*
+/**
  * @brief SNMP v1 or v2c Get query value.
  *
  * param[in]    peername    Target host in [protocol:]address[:port] format.
@@ -379,7 +392,7 @@ snmpv1v2c_get (const char *peername, const char *community, const char *oid_str,
   /* As we spawn the process asyncronously, we don't know the exit
      status of the process. Therefore we need to check for errors in
      the output.
-     We assume that if there is no erros, we have an output.
+     We assume a valid output if there is no erros.
   */
   check_spwan_output (serr, result);
   if (result && *result[0] != '\0')
@@ -402,7 +415,7 @@ snmpv1v2c_get (const char *peername, const char *community, const char *oid_str,
   return 0;
 }
 
-/*
+/**
  * @brief SNMPv3 Get query value.
  *
  * param[in]    peername    Target host in [protocol:]address[:port] format.

--- a/nasl/nasl_snmp.h
+++ b/nasl/nasl_snmp.h
@@ -28,9 +28,5 @@ nasl_snmpv1_get (lex_ctxt *);
 tree_cell *
 nasl_snmpv2c_get (lex_ctxt *);
 
-#ifdef HAVE_NETSNMP
-
 tree_cell *
 nasl_snmpv3_get (lex_ctxt *);
-
-#endif /* HAVE_NETSNMP */

--- a/nasl/nasl_snmp.h
+++ b/nasl/nasl_snmp.h
@@ -22,13 +22,13 @@
  * @brief Headers of an API for SNMP used by NASL scripts.
  */
 
-#ifdef HAVE_NETSNMP
-
 tree_cell *
 nasl_snmpv1_get (lex_ctxt *);
 
 tree_cell *
 nasl_snmpv2c_get (lex_ctxt *);
+
+#ifdef HAVE_NETSNMP
 
 tree_cell *
 nasl_snmpv3_get (lex_ctxt *);


### PR DESCRIPTION
**What**:
Add alternative nasl function to perform snmp scan, spawning a new process and using the binary snmpget

** Why **
In case libsnmp is not present, but the binary, still have support for snmp scans

**How**:
running this nasl script with openvas-nasl against a target with a running snmp agent is a way to test the new functions. To test
the functions, be sure you don't have the libsnmp-dev installed or remove the add_definition of  "HAVE_NETSNMP" in nasl/CMakeLists.txt.

` openvas-nasl -X -d -D -i <path-to-script> snmp_test.nasl -t <ip-with-running-and_configured-snmp-server> `
``` 

include("misc_func.inc");
include("dump.inc");


oid = '.1.3.6.1.2.1.1.1.0';

## uncomment this line to test the error handling
#oid = '.1.3.6.1.2.1.1.1.0.3.3.3.3';
protocol = 'udp';
port = 161;
community = 'public';

display("version 1");
ret = snmpv1_get( port:port, oid:oid, protocol:protocol, community:community );
display (ret, "\n");

display("version 2c");
ret = snmpv2c_get( port:port, oid:oid, protocol:protocol, community:community );
display (ret, "\n");

user = "some user";
pass = "password_ultra_xxl";

display("version 3");
ret = snmpv3_get(port:port, protocol:"udp", username:user, oid:oid,
                  authpass:pass, authproto:"md5", privpass:pass,
                  privproto:"des");

display (ret, "\n");
``` 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
