### PR TITLE
Update requirement for libgnutls version to 3.6.4+ for tls1.3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Extend nasl lint to detect if function parameter is used twice. [#590](https://github.com/greenbone/openvas/pull/590)
-- Add support for TLSv1.3. [#588](https://github.com/greenbone/openvas/pull/588)
+- Add support for TLSv1.3. [#588](https://github.com/greenbone/openvas/pull/588)[#598](https://github.com/greenbone/openvas/pull/598)
+
 - Add alternative for supporting snmp during scans. [#594](https://github.com/greenbone/openvas/pull/594)
 - Add resolve_hostname_to_multiple_ips() NASL function. [#596](https://github.com/greenbone/openvas/pull/596)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ Prerequisites:
 * redis >= 3.2.0
 * libssh >= 0.6.0
 * libksba >= 1.0.7
-* libgnutls >= 3.2.15
+* libgnutls >= 3.6.4
 
 Prerequisites for building documentation:
 * Doxygen

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT PKG_CONFIG_FOUND)
 endif (NOT PKG_CONFIG_FOUND)
 
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
-pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
+pkg_check_modules (GNUTLS REQUIRED gnutls>=3.6.4)
 
 pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=20.8)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=20.8)


### PR DESCRIPTION
**What**:
Update requirement for libgnutls version to 3.6.4+ for tls1.3 support

**Why**:
 GnuTLS 3.6.4 supports version of TLS1.3 and it is the default version since GnuTLS 3.6.5. 
Debian Buster, our reference system has the version [3.6.7](https://packages.debian.org/search?lang=de&suite=buster&searchon=names&keywords=libgnutls)

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
