### PR TITLE
Add option to specify if a host can be scanned through its IPv4 and IPv6 in parallel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add scanner-only option to enable tls debugging. [#558](https://github.com/greenbone/openvas/pull/558)
 - Extend nasl lint to detect if function parameter is used twice. [#585](https://github.com/greenbone/openvas/pull/585)
 - Consider .csv files for checksum check and upload in redis cache. [#599](https://github.com/greenbone/openvas/pull/599)
-
+- Add option to specify if a host can be scanned through its IPv4 and IPv6 in parallel. [#604](https://github.com/greenbone/openvas/pull/604)
 ### Changed
 -Store results in main_kb instead of host_kb. [#550](https://github.com/greenbone/openvas/pull/550)
 

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -124,6 +124,9 @@ Whether to expand the target host's list of vhosts with values gathered from sou
 .IP non_simult_ports
 Some services (in particular SMB) do not appreciate multiple connections at the same time coming from the same host. This option allows you to prevent openvas to make two connections on the same given ports at the same time. The syntax of this option is "port1[, port2....]". Note that you can use the KB notation of openvas to designate a service formally. Ex: "139, Services/www", will prevent openvas from making two connections at the same time on port 139 and on every port which hosts a web server.
 
+.IP allow_simult_ips_same_host
+If set to no, this option prevent openvas to scan more than one different IPs (e.g. the IPv4 and IPv6 addresses) which belong to the same host at the same time. Default, yes.
+
 .IP plugins_timeout
 This is the maximum lifetime, in seconds of a plugin. It may happen that some plugins are slow because of the way they are written or the way the remote server behaves. This option allows you to make sure your scan is never caught in an endless loop because of a non-finishing plugin. Doesn't affect ACT_SCANNER plugins.
 

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -659,7 +659,7 @@ plug_set_key_len (struct script_infos *args, char *name, int type,
                   const void *value, size_t len)
 {
   kb_t kb = plug_get_kb (args);
-  int pos = 0; //Append the item on the right position of the list
+  int pos = 0; // Append the item on the right position of the list
 
   if (name == NULL || value == NULL)
     return;

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -659,12 +659,13 @@ plug_set_key_len (struct script_infos *args, char *name, int type,
                   const void *value, size_t len)
 {
   kb_t kb = plug_get_kb (args);
+  int pos = 0; //Append the item on the right position of the list
 
   if (name == NULL || value == NULL)
     return;
 
   if (type == ARG_STRING)
-    kb_item_add_str_unique (kb, name, value, len);
+    kb_item_add_str_unique (kb, name, value, len, pos);
   else if (type == ARG_INT)
     kb_item_add_int_unique (kb, name, GPOINTER_TO_SIZE (value));
   if (global_nasl_debug == 1)

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -341,7 +341,7 @@ main (int argc, char **argv)
       g_free (port_range);
     }
 
-  pos = 0; //Append the item on the right side of the list
+  pos = 0; // Append the item on the right side of the list
   while ((host = gvm_hosts_next (hosts)))
     {
       struct in6_addr ip6;

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -158,7 +158,7 @@ main (int argc, char **argv)
   gvm_host_t *host;
   static gchar *target = NULL;
   gchar *default_target = "127.0.0.1";
-  int mode = 0, err = 0;
+  int mode = 0, err = 0, pos;
   extern int global_nasl_debug;
   GSList *unresolved;
 
@@ -341,6 +341,7 @@ main (int argc, char **argv)
       g_free (port_range);
     }
 
+  pos = 0; //Append the item on the right side of the list
   while ((host = gvm_hosts_next (hosts)))
     {
       struct in6_addr ip6;
@@ -393,7 +394,7 @@ main (int argc, char **argv)
                                *kb_values_aux);
                       exit (1);
                     }
-                  kb_item_add_str_unique (kb, splits[0], splits[1], 0);
+                  kb_item_add_str_unique (kb, splits[0], splits[1], 0, pos);
                   kb_values_aux++;
                   g_strfreev (splits);
                 }

--- a/src/attack.c
+++ b/src/attack.c
@@ -1262,8 +1262,8 @@ attack_network (struct scan_globals *globals)
                   gvm_host_get_addr6 (host, &hostip);
                   addr6_to_str (&hostip, ip_str);
 
-                  // Re-add host at the end of the queue and reallocate the flag if
-                  // it was already set.
+                  // Re-add host at the end of the queue and reallocate the flag
+                  // if it was already set.
                   int flag_set = finish_signal_on_queue (alive_hosts_kb);
 
                   put_host_on_queue (alive_hosts_kb, ip_str);

--- a/src/attack.c
+++ b/src/attack.c
@@ -1171,9 +1171,8 @@ attack_network (struct scan_globals *globals)
           && (!allow_simult_ips_same_host && host_is_currently_scanned (host)))
         {
           sleep (1);
-          // Re-add host at the end of the list
-          gvm_hosts_add (hosts, host);
-          // set next host
+          // move the host at the end of the list and get the next host.
+          gvm_hosts_move_current_host_to_end (hosts);
           host = gvm_hosts_next (hosts);
           continue;
         }

--- a/src/attack.c
+++ b/src/attack.c
@@ -1023,7 +1023,7 @@ attack_network (struct scan_globals *globals)
   kb_t main_kb;
   GSList *unresolved;
   int duplicated_hosts;
-  int allow_simult_ips_same_hosts;
+  int allow_simult_ips_same_host;
 
   gboolean test_alive_hosts_only = prefs_get_bool ("test_alive_hosts_only");
   gvm_hosts_t *alive_hosts_list = NULL;
@@ -1159,7 +1159,7 @@ attack_network (struct scan_globals *globals)
   /*
    * Start the attack !
    */
-  allow_simult_ips_same_hosts = prefs_get_bool ("allow_simult_ips_same_host");
+  allow_simult_ips_same_host = prefs_get_bool ("allow_simult_ips_same_host");
   openvas_signal (SIGUSR1, handle_scan_stop_signal);
   while (host && !scan_is_stopped ())
     {
@@ -1167,7 +1167,7 @@ attack_network (struct scan_globals *globals)
       struct attack_start_args args;
       char *host_str;
 
-      if (!allow_simult_ips_same_hosts
+      if (!allow_simult_ips_same_host
           && host_is_currently_scanned (host)
           && !test_alive_hosts_only)
         {
@@ -1254,7 +1254,7 @@ attack_network (struct scan_globals *globals)
                   fork_sleep (1);
                 }
               
-              if (host && !allow_simult_ips_same_hosts
+              if (host && !allow_simult_ips_same_host
                   && host_is_currently_scanned (host))
                 {
                   // Re-add host at the end of the queue.

--- a/src/attack.c
+++ b/src/attack.c
@@ -1262,6 +1262,7 @@ attack_network (struct scan_globals *globals)
                   int flag_set = finish_signal_on_queue (alive_hosts_kb);
 
                   put_host_on_queue (alive_hosts_kb, gvm_host_value_str(host));
+                  gvm_host_free (host);
                   if (flag_set)
                     realloc_finish_signal_on_queue (alive_hosts_kb);
                 }

--- a/src/attack.c
+++ b/src/attack.c
@@ -1253,13 +1253,17 @@ attack_network (struct scan_globals *globals)
                 {
                   fork_sleep (1);
                 }
-              
+
               if (host && !allow_simult_ips_same_host
                   && host_is_currently_scanned (host))
                 {
-                  // Re-add host at the end of the queue.
+                  // Re-add host at the end of the queue and reallocate the flag if
+                  // it was already set.
+                  int flag_set = finish_signal_on_queue (alive_hosts_kb);
+
                   put_host_on_queue (alive_hosts_kb, gvm_host_value_str(host));
-                  realloc_finish_signal_on_queue (alive_hosts_kb);
+                  if (flag_set)
+                    realloc_finish_signal_on_queue (alive_hosts_kb);
                 }
               else if (host)
                 gvm_hosts_add (alive_hosts_list, host);

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -28,13 +28,13 @@
 #include "../misc/network.h" /* for internal_recv */
 #include "utils.h"           /* for data_left() */
 
+#include <errno.h>               /* for errno() */
+#include <glib.h>                /* for g_free() */
 #include <gvm/base/networking.h> /* for gvm_resolve_list */
-#include <errno.h>    /* for errno() */
-#include <glib.h>     /* for g_free() */
-#include <stdio.h>    /* for snprintf() */
-#include <string.h>   /* for strlen() */
-#include <sys/wait.h> /* for waitpid() */
-#include <unistd.h>   /* for close() */
+#include <stdio.h>               /* for snprintf() */
+#include <string.h>              /* for strlen() */
+#include <sys/wait.h>            /* for waitpid() */
+#include <unistd.h>              /* for close() */
 
 #undef G_LOG_DOMAIN
 /**
@@ -284,14 +284,14 @@ host_is_currently_scanned (gvm_host_t *host_to_check)
   GSList *list, *tmp;
   char *vhost = NULL;
 
-  hosts_read();
+  hosts_read ();
 
   if (h == NULL)
-      return 0;
+    return 0;
 
   vhost = gvm_host_reverse_lookup (host_to_check);
   if (!vhost)
-      return 0;
+    return 0;
 
   list = tmp = gvm_resolve_list (vhost);
   g_free (vhost);

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -28,6 +28,7 @@
 #include "../misc/network.h" /* for internal_recv */
 #include "utils.h"           /* for data_left() */
 
+#include <gvm/base/networking.h> /* for gvm_resolve_list */
 #include <errno.h>    /* for errno() */
 #include <glib.h>     /* for g_free() */
 #include <stdio.h>    /* for snprintf() */
@@ -266,5 +267,52 @@ hosts_read (void)
   hosts_read_data ();
   usleep (500000);
 
+  return 0;
+}
+
+/**
+ * @brief Returns 1 if the host is being scanned. 0 otherwhise.
+ *
+ * It checks not only the main IP of the host, but also the ips
+ * that a dns-lookup returns.
+ */
+int
+host_is_currently_scanned (gvm_host_t *host_to_check)
+{
+  struct host *h = hosts;
+
+  GSList *list, *tmp;
+  char *vhost = NULL;
+
+  hosts_read();
+
+  if (h == NULL)
+      return 0;
+
+  vhost = gvm_host_reverse_lookup (host_to_check);
+  if (!vhost)
+      return 0;
+
+  list = tmp = gvm_resolve_list (vhost);
+  g_free (vhost);
+  while (tmp)
+    {
+      h = hosts;
+      char buffer[INET6_ADDRSTRLEN];
+      addr6_to_str (tmp->data, buffer);
+
+      while (h != NULL)
+        {
+          if (!strcasecmp (h->name, buffer))
+            {
+              g_slist_free_full (list, g_free);
+              return 1;
+            }
+          h = h->next;
+        }
+      tmp = tmp->next;
+    }
+
+  g_slist_free_full (list, g_free);
   return 0;
 }

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -27,6 +27,7 @@
 #define HOSTS_H
 
 #include "../misc/scanneraux.h"
+#include <gvm/base/hosts.h> /* for gvm_host_t */
 
 int
 hosts_init (int);
@@ -45,4 +46,8 @@ hosts_stop_all (void);
 
 void
 host_set_time (kb_t, char *, char *);
+
+int
+host_is_currently_scanned (gvm_host_t *);
+
 #endif

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -27,6 +27,7 @@
 #define HOSTS_H
 
 #include "../misc/scanneraux.h"
+
 #include <gvm/base/hosts.h> /* for gvm_host_t */
 
 int

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -129,6 +129,7 @@ static openvas_option openvas_defaults[] = {
   {"vendor_version", "\0"},
   {"test_alive_hosts_only", "no"},
   {"debug_tls", "0"},
+  {"allow_simult_ips_same_host", "yes"},
   {NULL, NULL}};
 
 static void


### PR DESCRIPTION
**What**:
If the parallel scan of IPv4 and IPv6 addresses of the same host is not allowed, the scanner will serialize the scans.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Some services do not appreciate multiple connections at the same time coming from the same host.  Valid for fragile services as well which could get in trouble if we're scanning them in parallel.

<!-- Why are these changes necessary? -->

**How**:

Set `allow_simult_ips_same_host = yes`
Scan a target with two IPs, which reverse-lookup resolves to the same hostname (e.g. IPv4 and IPv6 of the same host set in the /etc/hosts local file can be a test case). Expected: both IPs must be scanned in parallel

Set now `allow_simult_ips_same_host = no`
Run the same scan as before. Expected: the IPs are not scanned in parallel.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
