### PR TITLE
Fix wmi query when there is no error but empty answer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Send message to the client with hosts count. [#606](https://github.com/greenbone/openvas/pull/606)
 
 ### Changed
-- Downgrade wmi queries log level for common errors. [#602](https://github.com/greenbone/openvas/pull/602)
+- Downgrade wmi queries log level for common errors.
+  [#602](https://github.com/greenbone/openvas/pull/602)
+  [#607](https://github.com/greenbone/openvas/pull/607)
 
 ### Fixed
 - Fork vhosts before creating the socket.[#576](https://github.com/greenbone/openvas/pull/576)

--- a/nasl/nasl_wmi.c
+++ b/nasl/nasl_wmi.c
@@ -256,6 +256,8 @@ nasl_wmi_query (lex_ctxt *lexic)
       g_debug ("wmi_query: WMI query failed '%s'", query);
       return NULL;
     }
+  else if (res == NULL)
+    return NULL;
 
   retc->x.str_val = strdup (res);
   retc->size = strlen (res);
@@ -364,6 +366,9 @@ nasl_wmi_query_rsop (lex_ctxt *lexic)
       g_debug ("wmi_query_rsop: WMI query failed");
       return NULL;
     }
+  else if (res == NULL)
+    return NULL;
+
   retc->x.str_val = strdup (res);
   retc->size = strlen (res);
 


### PR DESCRIPTION
**What**:
Fix wmi query when there is no error but empty answer.


**Why**:
It needs to check for a null pointer before strdup

**How**:
Running a scan against a target with smb credential, no sigsegv must be logged.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
