### PR TITLE
Use metric when finding best route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check if another forked child has already added the same vhost. [#581](https://github.com/greenbone/openvas/pull/581)
 - Send duplicated hosts as dead hosts to ospd, to adjust scan progress calculation. [#586](https://github.com/greenbone/openvas/pull/586)
 - Only send the signal if the pid is a positive value. [#593](https://github.com/greenbone/openvas/pull/593)
+- When routes with same mask are found the route with the better metric is chosen. [#593](https://github.com/greenbone/openvas/pull/593)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -983,6 +983,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
     struct interface_info *dev;
     unsigned long mask;
     unsigned long dest;
+    unsigned long metric;
   } myroutes[MAXROUTES];
   int numinterfaces = 0;
   char *p, *endptr;
@@ -1040,7 +1041,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
                     "Failed to determine Destination from /proc/net/route");
                   continue;
                 }
-              for (i = 0; i < 6; i++)
+              for (i = 0; i < 5; i++)
                 {
                   p = strtok (NULL, " \t\n");
                   if (!p)
@@ -1053,6 +1054,14 @@ routethrough (struct in_addr *dest, struct in_addr *source)
                              i + 2);
                   continue;
                 }
+              endptr = NULL;
+              myroutes[numroutes].metric = strtol (p, &endptr, 10);
+              if (!endptr || *endptr)
+                {
+                  g_message ("Failed to determine metric from /proc/net/route");
+                  continue;
+                }
+              p = strtok (NULL, " \t\n");
               endptr = NULL;
               myroutes[numroutes].mask = strtoul (p, &endptr, 16);
               if (!endptr || *endptr)

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -1121,8 +1121,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
   for (i = 0; i < numroutes; i++)
     {
       /* Matching route found */
-      if ((dest->s_addr & myroutes[i].mask)
-          == myroutes[i].dest)
+      if ((dest->s_addr & myroutes[i].mask) == myroutes[i].dest)
         {
           /* First time a match is found */
           if (-1 == best_match)


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Currently for a destination address the last entry in the routes table which matches will be taken even if the last entry has the same mask and worse metric.

Now metric is also taken into account. 

**Why**:

<!-- Why are these changes necessary? -->

Wrong interface might be chosen otherwise.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
