### PR TITLE
End the scanner in a better way if the host list is malformed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Send duplicated hosts as dead hosts to ospd, to adjust scan progress calculation. [#586](https://github.com/greenbone/openvas/pull/586)
 - Only send the signal if the pid is a positive value. [#593](https://github.com/greenbone/openvas/pull/593)
 - When routes with same mask are found the route with the better metric is chosen. [#593](https://github.com/greenbone/openvas/pull/593)
+- Fix malformed target. [#625](https://github.com/greenbone/openvas/pull/625)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -1074,8 +1074,18 @@ attack_network (struct scan_globals *globals)
   max_checks = get_max_checks_number ();
 
   hosts = gvm_hosts_new (hostlist);
-  unresolved = gvm_hosts_resolve (hosts);
+  if (hosts == NULL)
+    {
+      connect_main_kb (&main_kb);
+      message_to_client (
+        main_kb, "Invalid target list.", NULL, NULL, "ERRMSG");
+      kb_lnk_reset (main_kb);
+      g_warning ("Invalid target list. Scan terminated.");
+      set_scan_status ("finished");
+      goto stop;
+    }
 
+  unresolved = gvm_hosts_resolve (hosts);
   while (unresolved)
     {
       g_warning ("Couldn't resolve hostname '%s'", (char *) unresolved->data);

--- a/src/attack.c
+++ b/src/attack.c
@@ -1076,9 +1076,9 @@ attack_network (struct scan_globals *globals)
   hosts = gvm_hosts_new (hostlist);
   if (hosts == NULL)
     {
+      sprintf (buf, "Invalid target list: %s.", hostlist);
       connect_main_kb (&main_kb);
-      message_to_client (
-        main_kb, "Invalid target list.", NULL, NULL, "ERRMSG");
+      message_to_client (main_kb, buf, NULL, NULL, "ERRMSG");
       kb_lnk_reset (main_kb);
       g_warning ("Invalid target list. Scan terminated.");
       set_scan_status ("finished");

--- a/src/attack.c
+++ b/src/attack.c
@@ -174,11 +174,12 @@ static void
 message_to_client (kb_t kb, const char *msg, const char *ip_str,
                    const char *port, const char *type)
 {
-  char buf[2048];
+  char *buf;
 
-  sprintf (buf, "%s|||%s|||%s||| |||%s", type, ip_str ?: "", port ?: " ",
-           msg ?: "No error.");
+  buf = g_strdup_printf ("%s|||%s|||%s||| |||%s", type, ip_str ?: "",
+                         port ?: " ", msg ?: "No error.");
   kb_item_push_str (kb, "internal/results", buf);
+  g_free (buf);
 }
 
 static void
@@ -1076,9 +1077,11 @@ attack_network (struct scan_globals *globals)
   hosts = gvm_hosts_new (hostlist);
   if (hosts == NULL)
     {
-      sprintf (buf, "Invalid target list: %s.", hostlist);
+      char *buffer;
+      buffer = g_strdup_printf ("Invalid target list: %s.", hostlist);
       connect_main_kb (&main_kb);
-      message_to_client (main_kb, buf, NULL, NULL, "ERRMSG");
+      message_to_client (main_kb, buffer, NULL, NULL, "ERRMSG");
+      g_free (buffer);
       kb_lnk_reset (main_kb);
       g_warning ("Invalid target list. Scan terminated.");
       set_scan_status ("finished");


### PR DESCRIPTION
**What**:
End the scanner in a better way if the host list is malformed and send a message to the client in case of invalid target list

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
If the target host list is not empty but malformed, the hosts struct is NULL. Then gvm_hosts_resolve() segfaults
<!-- Why are these changes necessary? -->

**How**:
Start a scan with gvm-cli (gsa already checks for malformed target) wiht 192.168.0.1/32 as host target.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
