### PR TITLE
Add nasl function to get the scan main kb index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add option to specify if a host can be scanned through its IPv4 and IPv6 in parallel. [#604](https://github.com/greenbone/openvas/pull/604)
 - Add insert_tcp_options and insert_tcp_v6_options nasl functions. [#618](https://github.com/greenbone/openvas/pull/618)
 - Add get_tcp_option and extend dump_tcp_packet nasl functions. [#621](https://github.com/greenbone/openvas/pull/621)
+- Add nasl function to get the scan main kb index. [#628](https://github.com/greenbone/openvas/pull/628)
 
 ### Changed
 - Store results in main_kb instead of host_kb. [#550](https://github.com/greenbone/openvas/pull/550)

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -95,6 +95,7 @@ static init_func libfuncs[] = {
   {"get_kb_item", get_kb_item},
   {"get_kb_list", get_kb_list},
   {"get_host_kb_index", get_host_kb_index},
+  {"get_scan_main_kb_index", get_scan_main_kb_index},
   {"security_message", security_message},
   {"log_message", log_message},
   {"error_message", error_message},

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -790,6 +790,33 @@ get_host_kb_index (lex_ctxt *lexic)
   return retc;
 }
 
+/**
+ * @brief Get the main kb index of the current running scan.
+ *
+ * @param[in] lexic     NASL lexer.
+ *
+ * @return lex cell containing the scan main kb index as positive integer.
+ *         NULL otherwise
+ */
+tree_cell *
+get_scan_main_kb_index (lex_ctxt *lexic)
+{
+  struct script_infos *script_infos = lexic->script_infos;
+  int val;
+  tree_cell *retc;
+
+  val = kb_get_kb_index (script_infos->results);
+  if (val >= 0)
+    {
+      retc = alloc_typed_cell (CONST_INT);
+      retc->x.i_val = val;
+    }
+  else
+    return NULL;
+
+  return retc;
+}
+
 tree_cell *
 replace_kb_item (lex_ctxt *lexic)
 {

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -97,6 +97,9 @@ tree_cell *
 get_host_kb_index (lex_ctxt *);
 
 tree_cell *
+get_scan_main_kb_index (lex_ctxt *);
+
+tree_cell *
 get_kb_item (lex_ctxt *);
 
 tree_cell *


### PR DESCRIPTION
**What**:
Add nasl function to get the scan main kb index.
The functions returns a integer, the redis db index of the scan kb
related to the host running the plugin.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Need by notus, to know where to store the results.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
