### PR TITLE
Fix rsync errors due to IP blocking.

### DIFF
--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -321,6 +321,9 @@ is_feed_current () {
       exit 1
     fi
   else
+    # Sleep for five seconds (a previous feed might have been synced a few seconds before) to prevent
+    # IP blocking due to network equipment in between keeping the previous connection too long open.
+    sleep 5
     log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     eval "$RSYNC -ltvrP \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$FEED_INFO_TEMP_DIR\""
     if [ $? -ne 0 ]
@@ -354,6 +357,9 @@ is_feed_current () {
 }
 
 do_rsync_community_feed () {
+  # Sleep for five seconds (a previous feed might have been synced a few seconds before) to prevent
+  # IP blocking due to network equipment in between keeping the previous connection too long open.
+  sleep 5
   log_notice "Configured NVT rsync feed: $COMMUNITY_NVT_RSYNC_FEED"
   mkdir -p "$NVT_DIR"
   eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED\" \"$NVT_DIR\" --exclude=plugin_feed_info.inc"
@@ -361,6 +367,9 @@ do_rsync_community_feed () {
     log_err "rsync failed."
     exit 1
   fi
+  # Sleep for five seconds (after the above rsync call) to prevent IP blocking due
+  # to network equipment in between keeping the previous connection too long open.
+  sleep 5
   eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$NVT_DIR\""
   if [ $? -ne 0 ] ; then
     log_err "rsync failed."


### PR DESCRIPTION
**What**:

Replaces #335. I have also updated this PR so that:
- the sleep is only done for the GCF and not for the GSF
- a 5 seconds sleep is used according to https://community.greenbone.net/t/connection-refused-111-greenbone-nvt-sync/7457/13
- a short sleep before is_feed_current is used as well

Also see **Why** below

**Why**:

From #335:

> Two rsync commands run in fairly quick succession to check if the feed is current and sync down new changes if it is not. I've found these run too quickly most of the time and the second rsync is blocked by the server which causes the update to fail. Adding a delay before the second rsync resolves the issue.

See various ongoing topics at the community portal like e.g.:

https://community.greenbone.net/t/connection-refused-111-greenbone-nvt-sync/7457

or the related PRs for gvmd here: greenbone/gvmd/pull/326, greenbone/gvmd/pull/1372

**How did you test it**:

No testing done as it just adds additional sleep commands

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry