### PR TITLE
Add timeout argument to ssh_connect() nasl function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add resolve_hostname_to_multiple_ips() NASL function. [#596](https://github.com/greenbone/openvas/pull/596)
 - Send message to the client with hosts count. [#606](https://github.com/greenbone/openvas/pull/606)
 - Use nasl_perror on invalid input and add more documentation. [#608](https://github.com/greenbone/openvas/pull/608)
+- Add timeout argument to ssh_connect() nasl function to set the connection timeout. [631](https://github.com/greenbone/openvas/pull/631)
 
 ### Changed
 - Downgrade wmi queries log level for common errors.

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -242,6 +242,7 @@ nasl_ssh_connect (lex_ctxt *lexic)
   unsigned int tbl_slot;
   int verbose = 0;
   int forced_sock = -1;
+  long timeout; // in seconds
 
   sock = get_int_var_by_name (lexic, "socket", 0);
   if (sock)
@@ -262,6 +263,18 @@ nasl_ssh_connect (lex_ctxt *lexic)
                  nasl_get_function_name (), nasl_get_plugin_filename ());
       return NULL;
     }
+
+  timeout = get_int_var_by_name (lexic, "timeout", 0);
+  if (timeout > 0)
+    if (ssh_options_set (session, SSH_OPTIONS_TIMEOUT, &timeout))
+      {
+        g_message ("Function %s called from %s: "
+                   "Failed to set SSH Connection Timeout to %ld seconds: %s",
+                   nasl_get_function_name (), nasl_get_plugin_filename (), timeout,
+                   ssh_get_error (session));
+        ssh_free (session);
+        return NULL;
+      }
 
   if ((s = getenv ("OPENVAS_LIBSSH_DEBUG")))
     {

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -222,6 +222,9 @@ extern int lowest_socket;
  *
  * - @a scciphers SSH server-to-client ciphers.
  *
+ * - @a timeout Set a timeout for the connection in seconds. Defaults to 10
+ * seconds (defined by libssh internally) if not given.
+ *
  * @naslret An integer to identify the ssh session. Zero on error.
  *
  * @param[in] lexic Lexical context of NASL interpreter.
@@ -268,10 +271,11 @@ nasl_ssh_connect (lex_ctxt *lexic)
   if (timeout > 0)
     if (ssh_options_set (session, SSH_OPTIONS_TIMEOUT, &timeout))
       {
-        g_message ("Function %s called from %s: "
-                   "Failed to set SSH Connection Timeout to %ld seconds: %s",
-                   nasl_get_function_name (), nasl_get_plugin_filename (), timeout,
-                   ssh_get_error (session));
+        g_message (
+          "Function %s called from %s: "
+          "Failed to set the SSH connection timeout to %ld seconds: %s",
+          nasl_get_function_name (), nasl_get_plugin_filename (), timeout,
+          ssh_get_error (session));
         ssh_free (session);
         return NULL;
       }


### PR DESCRIPTION
**What**:
Add timeout argument to ssh_connect() nasl function to set the connection timeout in seconds

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Some ssh server take too long to return the prompt for the password
<!-- Why are these changes necessary? -->

**How**:
As I didn't have a ssh server with the issue, I have used the paramiko server demo and added some sleep() before returning the prompt. That simulates the issue in the server side. Then, I used the next nasl script:

` openvas-nasl -X -B -d -i /home/jnicola/install/var/lib/openvas/plugins -t localhost ssh_timeout.nasl`

```
login = "robey";
password = "foo";
port = 2200;

#Sockets
  soc = open_sock_tcp( port );
  if( ! soc ) exit( 0 );
  display ("socket opened:",soc);

#Use the new timeout option. It must be greather than the sleep set in the demo server
  sess = ssh_connect( socket:soc, timeout:15 );
  display("session: ", sess);

if( ! sess )
  return 0;

if( ssh_userauth( sess, login:login, password:password ) ) {
  ssh_disconnect( sess );
  last_sess = 0;
  return 0;
}
```


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
