### PR TITLE
Add new scanner only option to enable the table driven lsc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add insert_tcp_options and insert_tcp_v6_options nasl functions. [#618](https://github.com/greenbone/openvas/pull/618)
 - Add get_tcp_option and extend dump_tcp_packet nasl functions. [#621](https://github.com/greenbone/openvas/pull/621)
 - Add nasl function to get the scan main kb index. [#628](https://github.com/greenbone/openvas/pull/628)
+- Add new scanner only option to enable the table driven lsc. [#632](https://github.com/greenbone/openvas/pull/632)
 
 ### Changed
 - Store results in main_kb instead of host_kb. [#550](https://github.com/greenbone/openvas/pull/550)

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -91,7 +91,7 @@ Use a debug level over 10 to enable all debugging options.
 If this option is set to 'yes', openvas will log the name of each plugin being loaded at startup, or each time it receives the HUP signal.
 
 .IP table_driven_lsc
-If this options is set to 'yes', openvas enables the local security security checks via the table-drive Notus scanner.
+If this options is set to 'yes', openvas enables the local security checks via the table-driven Notus scanner, perfoming the Notus metadata checksum check which allows the metadata upload into redis.
 
 .IP cgi_path
 By default, openvas looks for default CGIs in /cgi-bin and /scripts. You may

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -90,6 +90,9 @@ Use a debug level over 10 to enable all debugging options.
 .IP log_plugins_name_at_load
 If this option is set to 'yes', openvas will log the name of each plugin being loaded at startup, or each time it receives the HUP signal.
 
+.IP table_driven_lsc
+If this options is set to 'yes', openvas enables the local security security checks via the table-drive Notus scanner.
+
 .IP cgi_path
 By default, openvas looks for default CGIs in /cgi-bin and /scripts. You may
 change these to something else to reflect the policy of your site. The syntax of this option is the same as the shell $PATH variable: path1:path2:...

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -99,7 +99,7 @@ collect_nvts (const char *folder, const char *subdir, GSList *files)
         }
       else if (g_str_has_suffix (fname, ".nasl")
                || ((g_str_has_suffix (fname, ".csv")
-                    && prefs_get_bool ("table_drive_lsc"))))
+                    && prefs_get_bool ("table_driven_lsc"))))
         files = g_slist_prepend (files, g_build_filename (subdir, fname, NULL));
       g_free (path);
       fname = g_dir_read_name (dir);
@@ -311,7 +311,8 @@ plugins_reload_from_dir (void *folder)
         }
       /* Perform integrity check of csv files if table_driven_lsc
        * is enabled. */
-      if (g_str_has_suffix (name, ".csv") && prefs_get_bool ("table_drive_lsc"))
+      if (g_str_has_suffix (name, ".csv")
+          && prefs_get_bool ("table_driven_lsc"))
         {
           if (csv_vt_list_add (folder, name))
             err_count++;

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -98,7 +98,8 @@ collect_nvts (const char *folder, const char *subdir, GSList *files)
             g_free (new_subdir);
         }
       else if (g_str_has_suffix (fname, ".nasl")
-               || g_str_has_suffix (fname, ".csv"))
+               || ((g_str_has_suffix (fname, ".csv")
+                    && prefs_get_bool ("table_drive_lsc"))))
         files = g_slist_prepend (files, g_build_filename (subdir, fname, NULL));
       g_free (path);
       fname = g_dir_read_name (dir);
@@ -308,7 +309,9 @@ plugins_reload_from_dir (void *folder)
           if (nasl_plugin_add (folder, name))
             err_count++;
         }
-      if (g_str_has_suffix (name, ".csv"))
+      /* Perform integrity check of csv files if table_driven_lsc
+       * is enabled. */
+      if (g_str_has_suffix (name, ".csv") && prefs_get_bool ("table_drive_lsc"))
         {
           if (csv_vt_list_add (folder, name))
             err_count++;

--- a/src/utils.c
+++ b/src/utils.c
@@ -257,6 +257,8 @@ is_scanner_only_pref (const char *pref)
       || !strcmp (pref, "nasl_no_signature_check")
       || !strcmp (pref, "vendor_version") || !strcmp (pref, "drop_privileges")
       || !strcmp (pref, "debug_tls")
+      /* Enable/disable table driven local security checks via Notus scanner. */
+      || !strcmp (pref, "table_driven_lsc")
       /* Preferences starting with sys_ are scanner-side only. */
       || !strncmp (pref, "sys_", 4))
     return 1;


### PR DESCRIPTION
**What**:
Add new scanner only option to enable the table driven lsc.
If enabled, perform the checksum check of the files and stores
the necessary in the redis cache to perform the lsc scan via Notus.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Necessary for enabling table driven scans
<!-- Why are these changes necessary? -->

**How**:
check in redis if the keys for the file are present.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
