### PR TITLE
Add drop_privileges_user for fork()ed processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add get_tcp_option and extend dump_tcp_packet nasl functions. [#621](https://github.com/greenbone/openvas/pull/621)
 - Add nasl function to get the scan main kb index. [#628](https://github.com/greenbone/openvas/pull/628)
 - Add new scanner only option to enable the table driven lsc. [#632](https://github.com/greenbone/openvas/pull/632)
+- Add new scanner only option for spawinng processes with a different owner. [#634](https://github.com/greenbone/openvas/pull/634)
 
 ### Changed
 - Store results in main_kb instead of host_kb. [#550](https://github.com/greenbone/openvas/pull/550)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add get_tcp_option and extend dump_tcp_packet nasl functions. [#621](https://github.com/greenbone/openvas/pull/621)
 - Add nasl function to get the scan main kb index. [#628](https://github.com/greenbone/openvas/pull/628)
 - Add new scanner only option to enable the table driven lsc. [#632](https://github.com/greenbone/openvas/pull/632)
-- Add new scanner only option for spawinng processes with a different owner. [#634](https://github.com/greenbone/openvas/pull/634)
+- Add new scanner only option for spawning NASL functions with a different owner. [#634](https://github.com/greenbone/openvas/pull/634)
 
 ### Changed
 - Store results in main_kb instead of host_kb. [#550](https://github.com/greenbone/openvas/pull/550)

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -222,7 +222,7 @@ the default value of this preference is 'no', meaning no change in behaviour.
 If a user is set, NASL functions can use this user to drop its root privilege.
 The new process owner is set only for those process calling a nasl function
 which supports a drop privileges action.
-This preference must not be mixed with 'drop_privileges'. If drop privileges is
+This preference must not be mixed with 'drop_privileges'. If 'drop_privileges' is
 enabled, this option should not be used, as drop_privileges sets the owner to
 'nobody'.
 

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -219,7 +219,7 @@ root privilege before launching any VT and the new process owner is 'nobody';
 the default value of this preference is 'no', meaning no change in behaviour.
 
 .IP nasl_drop_privileges_user
-If a user is set, some nasl function can use this user to drop its root privilege.
+If a user is set, NASL functions can use this user to drop its root privilege.
 The new process owner is set only for those process calling a nasl function
 which supports a drop privileges action.
 This preference must not be mixed with 'drop_privileges'. If drop privileges is

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -215,7 +215,7 @@ Notice that OpenVAS will spawn max_hosts * max_checks processes.
 
 .IP drop_privileges
 If this preference is set to 'yes', OpenVAS will attempt to drop its
-root privilege before launching any NVT and the new process owner is 'nobody';
+root privilege before launching any VT and the new process owner is 'nobody';
 the default value of this preference is 'no', meaning no change in behaviour.
 
 .IP nasl_drop_privileges_user

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -213,6 +213,19 @@ to be and it will also reduce network load and improve performance
 (obviously 1 is the minimum)
 Notice that OpenVAS will spawn max_hosts * max_checks processes.
 
+.IP drop_privileges
+If this preference is set to 'yes, openvas-scanner will attempt to drop its
+root privilege before launching any NVT and the new process owner is 'nobody';
+the default value of this preference is 'no', meaning no change in behaviour.
+
+.IP nasl_drop_privileges_user
+If a user is set, some nasl function can use this user to drop its root privilege.
+The new process owner is set only for those process calling a nasl function
+which supports a drop privileges action.
+This preference must not be mixed with 'drop_privileges'. If drop privileges is
+enabled, this option should not be used, as drop_privileges sets the owner to
+'nobody'.
+
 .IP vendor_version
 Use the alternate vendor instead of the default one during scans.
 

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -214,7 +214,7 @@ to be and it will also reduce network load and improve performance
 Notice that OpenVAS will spawn max_hosts * max_checks processes.
 
 .IP drop_privileges
-If this preference is set to 'yes, openvas-scanner will attempt to drop its
+If this preference is set to 'yes', OpenVAS will attempt to drop its
 root privilege before launching any NVT and the new process owner is 'nobody';
 the default value of this preference is 'no', meaning no change in behaviour.
 

--- a/doc/openvas.8.in
+++ b/doc/openvas.8.in
@@ -223,7 +223,7 @@ If a user is set, NASL functions can use this user to drop its root privilege.
 The new process owner is set only for those process calling a nasl function
 which supports a drop privileges action.
 This preference must not be mixed with 'drop_privileges'. If 'drop_privileges' is
-enabled, this option should not be used, as drop_privileges sets the owner to
+enabled, this option should not be used, as 'drop_privileges' sets the owner to
 'nobody'.
 
 .IP vendor_version

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -102,7 +102,8 @@ pread_streams (int fdout, int fderr)
  * @param[in] lexic   Lexical context of NASL interpreter.
  * @param[in] cmd Command to run.
  * @param[in] argv List of arguments.
- * @param[in] cd If set to TRUE the scanner will change it's current directory to the directory where the command was found.
+ * @param[in] cd If set to TRUE the scanner will change it's current directory
+ * to the directory where the command was found.
  * @param[in] drop_privileges_user Owner of the spawned process.
  *
  * @return The content of stderr or stdout written by the spawn process or NULL.

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -31,16 +31,16 @@
 #include "nasl_tree.h"
 #include "nasl_var.h"
 
+#include <errno.h>                    /* for errno */
+#include <fcntl.h>                    /* for open */
+#include <glib.h>                     /* for g_get_tmp_dir */
 #include <gvm/base/drop_privileges.h> /* for drop_privileges */
-#include <errno.h>     /* for errno */
-#include <fcntl.h>     /* for open */
-#include <glib.h>      /* for g_get_tmp_dir */
-#include <signal.h>    /* for kill */
-#include <string.h>    /* for strncpy */
-#include <sys/param.h> /* for MAXPATHLEN */
-#include <sys/stat.h>  /* for stat */
-#include <sys/wait.h>  /* for waitpid */
-#include <unistd.h>    /* for getcwd */
+#include <signal.h>                   /* for kill */
+#include <string.h>                   /* for strncpy */
+#include <sys/param.h>                /* for MAXPATHLEN */
+#include <sys/stat.h>                 /* for stat */
+#include <sys/wait.h>                 /* for waitpid */
+#include <unistd.h>                   /* for getcwd */
 
 /* MAXPATHLEN doesn't exist on some architectures like hurd i386 */
 #ifndef MAXPATHLEN
@@ -95,6 +95,16 @@ pread_streams (int fdout, int fderr)
 }
 
 /** @todo Suspects to glib replacements, all path related stuff. */
+/**
+ * @brief Spawn a process
+ *
+ * @param[in] lexic   Lexical context of NASL interpreter.
+ * @param[in] cmd Command to be run.
+ * @param[in] argv List of arguments.
+ * @param[in] drop_privileges Owner of the spawned process.
+ *
+ * @return The content of stderr or stdout written by the spawn process or Null
+ */
 tree_cell *
 nasl_pread (lex_ctxt *lexic)
 {
@@ -115,7 +125,7 @@ nasl_pread (lex_ctxt *lexic)
   new_user = get_str_var_by_name (lexic, "drop_privileges");
   if (new_user)
     {
-      if (drop_privileges(new_user, &error))
+      if (drop_privileges (new_user, &error))
         {
           if (error)
             {

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -35,6 +35,7 @@
 #include <fcntl.h>                    /* for open */
 #include <glib.h>                     /* for g_get_tmp_dir */
 #include <gvm/base/drop_privileges.h> /* for drop_privileges */
+#include <gvm/base/prefs.h>           /* for prefs_get_bool() */
 #include <signal.h>                   /* for kill */
 #include <string.h>                   /* for strncpy */
 #include <sys/param.h>                /* for MAXPATHLEN */
@@ -123,7 +124,7 @@ nasl_pread (lex_ctxt *lexic)
     }
 
   new_user = get_str_var_by_name (lexic, "drop_privileges_user");
-  if (new_user)
+  if (new_user && !prefs_get_bool ("drop_privileges"))
     {
       if (drop_privileges (new_user, &error))
         {

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -99,11 +99,11 @@ pread_streams (int fdout, int fderr)
  * @brief Spawn a process
  *
  * @param[in] lexic   Lexical context of NASL interpreter.
- * @param[in] cmd Command to be run.
+ * @param[in] cmd Command to run.
  * @param[in] argv List of arguments.
- * @param[in] drop_privileges Owner of the spawned process.
+ * @param[in] drop_privileges_user Owner of the spawned process.
  *
- * @return The content of stderr or stdout written by the spawn process or Null
+ * @return The content of stderr or stdout written by the spawn process or NULL.
  */
 tree_cell *
 nasl_pread (lex_ctxt *lexic)
@@ -122,7 +122,7 @@ nasl_pread (lex_ctxt *lexic)
       return NULL;
     }
 
-  new_user = get_str_var_by_name (lexic, "drop_privileges");
+  new_user = get_str_var_by_name (lexic, "drop_privileges_user");
   if (new_user)
     {
       if (drop_privileges (new_user, &error))

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -102,6 +102,7 @@ pread_streams (int fdout, int fderr)
  * @param[in] lexic   Lexical context of NASL interpreter.
  * @param[in] cmd Command to run.
  * @param[in] argv List of arguments.
+ * @param[in] cd If set to TRUE the scanner will change it's current directory to the directory where the command was found.
  * @param[in] drop_privileges_user Owner of the spawned process.
  *
  * @return The content of stderr or stdout written by the spawn process or NULL.

--- a/src/utils.c
+++ b/src/utils.c
@@ -256,6 +256,7 @@ is_scanner_only_pref (const char *pref)
       || !strcmp (pref, "log_plugins_name_at_load")
       || !strcmp (pref, "nasl_no_signature_check")
       || !strcmp (pref, "vendor_version") || !strcmp (pref, "drop_privileges")
+      || !strcmp (pref, "nasl_drop_privileges_user")
       || !strcmp (pref, "debug_tls")
       /* Enable/disable table driven local security checks via Notus scanner. */
       || !strcmp (pref, "table_driven_lsc")


### PR DESCRIPTION
**What**:
Add new scanner only option nasl_drop_privileges_user.
Extend nasl_pread() to accept a new argument drop_privileges_user. The new argument receive a user which will become the owner of the fork()ed process. 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To allow spawning a process with a different process uid. Normally, openvas runs as root privileges and this allows to drop privileges
<!-- Why are these changes necessary? -->

**How**:
- Add nasl_drop_privileges_user = <some-user> to openvas.conf
- Run a script which uses pread() nasl function passing the drop_privileges_user argument.
- Check that the process owner is the desired.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
