### PR TITLE
Fix ipv6 masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - When routes with same mask are found the route with the better metric is chosen. [#593](https://github.com/greenbone/openvas/pull/593)
 - Fix malformed target. [#625](https://github.com/greenbone/openvas/pull/625)
 - Fix snmp result. Only return the value and do not stop at the first \n. [#627](https://github.com/greenbone/openvas/pull/627)
+- Fix masking of IPv6 addresses. [#635](https://github.com/greenbone/openvas/pull/635)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -70,47 +70,41 @@ v6_getinterfaces (int *howmany);
 int
 getipv6routes (struct myroute *myroutes, int *numroutes);
 
-static void
-ipv6addrmask (struct in6_addr *in6addr, int mask)
+/**
+ * @brief Generate an ipv6 mask from the given ipv6 prefix.
+ *
+ * This function is a copy of the function ipv6_prefix_to_mask() obtained from
+ * GPL-2.0 licensed https://gitlab.com/ipcalc/ipcalc/-/blob/master/ipcalc.c.
+ *
+ * @param[in]   prefix  The ipv6 prefix.
+ * @param[out]  mask    The mask corresponding to the prefix.
+ *
+ * @return 0 on success, -1 on error.
+ **/
+int
+ipv6_prefix_to_mask (unsigned prefix, struct in6_addr *mask)
 {
-  int wordmask;
-  int word;
-  uint32_t *ptr;
-  uint32_t addr;
+  struct in6_addr in6;
+  int i, j;
 
-  word = mask / 32;
-  wordmask = mask % 32;
-  ptr = (uint32_t *) in6addr;
-  switch (word)
+  if (prefix > 128)
+    return -1;
+
+  memset (&in6, 0x0, sizeof (in6));
+  for (i = prefix, j = 0; i > 0; i -= 8, j++)
     {
-    case 0:
-      ptr[1] = ptr[2] = ptr[3] = 0;
-      addr = ptr[0];
-      addr = ntohl (addr) >> (32 - wordmask);
-      addr = htonl (addr << (32 - wordmask));
-      ptr[0] = addr;
-      break;
-    case 1:
-      ptr[2] = ptr[3] = 0;
-      addr = ptr[1];
-      addr = ntohl (addr) >> (32 - wordmask);
-      addr = htonl (addr << (32 - wordmask));
-      ptr[1] = addr;
-      break;
-    case 2:
-      ptr[3] = 0;
-      addr = ptr[2];
-      addr = ntohl (addr) >> (32 - wordmask);
-      addr = htonl (addr << (32 - wordmask));
-      ptr[2] = addr;
-      break;
-    case 3:
-      addr = ptr[3];
-      addr = ntohl (addr) >> (32 - wordmask);
-      addr = htonl (addr << (32 - wordmask));
-      ptr[3] = addr;
-      break;
+      if (i >= 8)
+        {
+          in6.s6_addr[j] = 0xff;
+        }
+      else
+        {
+          in6.s6_addr[j] = (unsigned long) (0xffU << (8 - i));
+        }
     }
+
+  memcpy (mask, &in6, sizeof (*mask));
+  return 0;
 }
 
 int

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -182,7 +182,7 @@ v6_ipaddr2devname (char *dev, int sz, struct in6_addr *addr)
     {
       char addr1[INET6_ADDRSTRLEN];
       char addr2[INET6_ADDRSTRLEN];
-      g_debug ("comparing addresses %s and %s\n",
+      g_debug ("comparing addresses %s and %s",
                inet_ntop (AF_INET6, addr, addr1, sizeof (addr1)),
                inet_ntop (AF_INET6, &mydevs[i].addr6, addr2, sizeof (addr2)));
       if (IN6_ARE_ADDR_EQUAL (addr, &mydevs[i].addr6))
@@ -365,10 +365,10 @@ v6_getinterfaces (int *howmany)
               mydevs[numinterfaces].mask.s6_addr32[1] = 0;
               mydevs[numinterfaces].mask.s6_addr32[2] = htonl (0xffff);
               mydevs[numinterfaces].mask.s6_addr32[3] = saddr->sin_addr.s_addr;
-              g_debug ("interface name is %s\n", ifa->ifa_name);
-              g_debug ("\tAF_INET family\n");
-              g_debug ("\taddress is %s\n", inet_ntoa (saddr->sin_addr));
-              g_debug ("\tnetmask is %s\n", inet_ntoa (saddr->sin_addr));
+              g_debug ("interface name is %s", ifa->ifa_name);
+              g_debug ("\tAF_INET family");
+              g_debug ("\taddress is %s", inet_ntoa (saddr->sin_addr));
+              g_debug ("\tnetmask is %s", inet_ntoa (saddr->sin_addr));
               numinterfaces++;
             }
           else if (family == AF_INET6)
@@ -384,14 +384,14 @@ v6_getinterfaces (int *howmany)
               memcpy (&(mydevs[numinterfaces].mask),
                       (char *) &(s6addr->sin6_addr), sizeof (struct in6_addr));
               numinterfaces++;
-              g_debug ("\tAF_INET6 family\n");
-              g_debug ("interface name is %s\n", ifa->ifa_name);
-              g_debug ("\taddress is %s\n",
+              g_debug ("\tAF_INET6 family");
+              g_debug ("interface name is %s", ifa->ifa_name);
+              g_debug ("\taddress is %s",
                        inet_ntop (AF_INET6, &s6addr->sin6_addr, ipaddr,
                                   sizeof (ipaddr)));
             }
           else
-            g_debug ("\tfamily is %d\n", ifa->ifa_addr->sa_family);
+            g_debug ("\tfamily is %d", ifa->ifa_addr->sa_family);
         }
       *howmany = numinterfaces;
 
@@ -516,7 +516,7 @@ v6_getsourceip (struct in6_addr *src, struct in6_addr *dst)
       src->s6_addr32[1] = 0;
       src->s6_addr32[2] = htonl (0xffff);
       src->s6_addr32[3] = sock.sin_addr.s_addr;
-      g_debug ("source address is %s\n",
+      g_debug ("source address is %s",
                inet_ntop (AF_INET6, src, name, sizeof (name)));
       close (sd);
     }
@@ -557,7 +557,7 @@ v6_getsourceip (struct in6_addr *src, struct in6_addr *dst)
       src->s6_addr32[2] = sock6.sin6_addr.s6_addr32[2];
       src->s6_addr32[3] = sock6.sin6_addr.s6_addr32[3];
       memcpy (src, &sock6.sin6_addr, sizeof (struct in6_addr));
-      g_debug ("source addrss is %s\n",
+      g_debug ("source addrss is %s",
                inet_ntop (AF_INET6, src, name, sizeof (name)));
       close (sd);
     }
@@ -613,7 +613,7 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
           p = strtok (NULL, " \t\n");
           endptr = NULL;
           dest = strtoul (p, &endptr, 16);
-          g_debug ("ipv4 dest is %s\n", p);
+          g_debug ("ipv4 dest is %s", p);
           if (!endptr || *endptr)
             {
               g_message ("Failed to determine Destination from"
@@ -645,7 +645,7 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
           while (mask & (1 << i++) && i < 32)
             ones++;
           myroutes[*numroutes].mask = ones + 96;
-          g_debug ("mask is %lu\n", myroutes[*numroutes].mask);
+          g_debug ("mask is %lu", myroutes[*numroutes].mask);
           if (!endptr || *endptr)
             {
               g_message ("Failed to determine mask from"
@@ -653,7 +653,7 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
               continue;
             }
 
-          g_debug ("#%d: for dev %s, The dest is %lX and the mask is %lX\n",
+          g_debug ("#%d: for dev %s, The dest is %lX and the mask is %lX",
                    *numroutes, iface, myroutes[*numroutes].dest,
                    myroutes[*numroutes].mask);
           for (i = 0; i < numinterfaces; i++)
@@ -709,7 +709,7 @@ getipv6routes (struct myroute *myroutes, int *numroutes)
           token = strtok (buf, " \t\n");
           if (token)
             {
-              g_debug ("first token is %s\n", token);
+              g_debug ("first token is %s", token);
               strncpy (destaddr, token, sizeof (destaddr) - 1);
               len = strlen (destaddr);
               for (i = 0, j = 0; j < len; j++)
@@ -719,7 +719,7 @@ getipv6routes (struct myroute *myroutes, int *numroutes)
                     v6addr[i++] = ':';
                 }
               v6addr[--i] = '\0';
-              g_debug ("ipv6 dest is %s\n", v6addr);
+              g_debug ("ipv6 dest is %s", v6addr);
               if (inet_pton (AF_INET6, v6addr, &in6addr) <= 0)
                 {
                   g_message ("invalid ipv6 addressd");
@@ -755,7 +755,7 @@ getipv6routes (struct myroute *myroutes, int *numroutes)
               }
           if (i == numinterfaces)
             g_message (
-              "Failed to find interface %s mentioned in /proc/net/ipv6_route\n",
+              "Failed to find interface %s mentioned in /proc/net/ipv6_route",
               iface);
           (*numroutes)++;
           if (*numroutes >= MAXROUTES)
@@ -889,7 +889,7 @@ v6_routethrough (struct in6_addr *dest, struct in6_addr *source)
             network.s6_addr[i] = dest->s6_addr[i] & mask.s6_addr[i];
 
           g_debug (
-            "comparing addresses %s and %s\n",
+            "comparing addresses %s and %s",
             inet_ntop (AF_INET6, &network, addr1, sizeof (addr1)),
             inet_ntop (AF_INET6, &myroutes[i].dest6, addr2, sizeof (addr2)));
           if (IN6_ARE_ADDR_EQUAL (&network, &myroutes[i].dest6))
@@ -902,10 +902,10 @@ v6_routethrough (struct in6_addr *dest, struct in6_addr *source)
                     {
                       if (myroutes[i].dev != NULL)
                         {
-                          g_debug ("copying address %s\n",
+                          g_debug ("copying address %s",
                                    inet_ntop (AF_INET6, &myroutes[i].dev->addr6,
                                               addr1, sizeof (addr1)));
-                          g_debug ("dev name is %s\n", myroutes[i].dev->name);
+                          g_debug ("dev name is %s", myroutes[i].dev->name);
                           memcpy (source, &myroutes[i].dev->addr6,
                                   sizeof (struct in6_addr));
                         }
@@ -947,7 +947,7 @@ v6_routethrough (struct in6_addr *dest, struct in6_addr *source)
           char addr2[INET6_ADDRSTRLEN];
 
           g_debug (
-            "comparing addresses %s and %s\n",
+            "comparing addresses %s and %s",
             inet_ntop (AF_INET6, &mydevs[i].addr6, addr1, sizeof (addr1)),
             inet_ntop (AF_INET6, &addy, addr2, sizeof (addr2)));
           if (IN6_ARE_ADDR_EQUAL (&mydevs[i].addr6, &addy))
@@ -1076,7 +1076,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
                   continue;
                 }
 
-              g_debug ("#%d: for dev %s, The dest is %lX and the mask is %lX\n",
+              g_debug ("#%d: for dev %s, The dest is %lX and the mask is %lX",
                        numroutes, iface, myroutes[numroutes].dest,
                        myroutes[numroutes].mask);
               for (i = 0; i < numinterfaces; i++)

--- a/misc/pcap_tests.c
+++ b/misc/pcap_tests.c
@@ -235,20 +235,65 @@ Ensure (pcap, islocalhost)
   assert_that (islocalhost (&addr), is_false);
 }
 
+/**
+ * @brief Apply mask to dest addr.
+ *
+ * @param[out]  network   Masked dest addr.
+ * @param[in]   dest      Destination addr.
+ * @param[in]   mask      Mask to apply.
+ */
+static void
+apply_ipv6_mask (struct in6_addr *network, struct in6_addr *dest,
+                 struct in6_addr *mask)
+{
+  for (int i = 0; i < (int) sizeof (struct in6_addr); i++)
+    network->s6_addr[i] = dest->s6_addr[i] & mask->s6_addr[i];
+}
+
+Ensure (pcap, ipv6_prefix_to_mask)
+{
+  struct in6_addr dest;
+  struct in6_addr result;
+  struct in6_addr mask;
+  struct in6_addr network;
+  const uint8_t byte_options[9] = {0xFF, 0x00, 0x80, 0xC0, 0xE0,
+                                   0xF0, 0xF8, 0xFC, 0xFE};
+
+  // create dst addr
+  const uint8_t addr_in[16] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                               0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  memcpy (dest.s6_addr, addr_in, sizeof addr_in);
+  // create expected result addr
+  const uint8_t result_in[16] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                 0xFF, 0xFF, 0xFF, 0xFF};
+  memcpy (result.s6_addr, result_in, sizeof result_in);
+
+  // check every possible bit mask
+  for (int i = 128; i > 0; i--)
+    {
+      ipv6_prefix_to_mask (i, &mask);
+      apply_ipv6_mask (&network, &dest, &mask);
+      int byte_to_modify = i / 8;
+      if (byte_to_modify != 16)
+        result.s6_addr[byte_to_modify] = byte_options[(i % 8) + 1];
+
+      assert_that (IN6_ARE_ADDR_EQUAL (&network, &result));
+    }
+}
+
 TestSuite *
 openvas_routethrough ()
 {
   TestSuite *suite = create_test_suite ();
   add_test_with_context (suite, pcap, routethrough_dst_is_localhost);
-  add_test_with_context (suite, pcap,
-                         routethrough_dst_is_not_localhost);
+  add_test_with_context (suite, pcap, routethrough_dst_is_not_localhost);
   add_test_with_context (suite, pcap, routethrough_no_src_dst_given);
-  add_test_with_context (suite, pcap,
-                         routethrough_src_globalsource_set);
-  add_test_with_context (suite, pcap,
-                         routethrough_src_globalsource_not_set);
+  add_test_with_context (suite, pcap, routethrough_src_globalsource_set);
+  add_test_with_context (suite, pcap, routethrough_src_globalsource_not_set);
   add_test_with_context (suite, pcap, v6_islocalhost);
   add_test_with_context (suite, pcap, islocalhost);
+  add_test_with_context (suite, pcap, ipv6_prefix_to_mask);
 
   return suite;
 }

--- a/misc/pcap_tests.c
+++ b/misc/pcap_tests.c
@@ -20,14 +20,14 @@
 
 #include <cgreen/cgreen.h>
 #include <cgreen/mocks.h>
-#include <gvm/boreas/alivedetection.h>
+#include <gvm/base/hosts.h>
 
-Describe (alivedetection);
-BeforeEach (alivedetection)
+Describe (pcap);
+BeforeEach (pcap)
 {
   cgreen_mocks_are (loose_mocks);
 }
-AfterEach (alivedetection)
+AfterEach (pcap)
 {
 }
 
@@ -70,7 +70,7 @@ __wrap_setsockopt (__attribute__ ((unused)) int sockfd,
 }
 
 /* If dst for routethrough() is localhost "lo" interface is returned. */
-Ensure (alivedetection, routethrough_dst_is_localhost)
+Ensure (pcap, routethrough_dst_is_localhost)
 {
   /* setup */
   g_socket_use_real = false;
@@ -98,7 +98,7 @@ Ensure (alivedetection, routethrough_dst_is_localhost)
 
 /* If dst is not null for routethrough() then another interface than "lo" is
  * returned. */
-Ensure (alivedetection, routethrough_dst_is_not_localhost)
+Ensure (pcap, routethrough_dst_is_not_localhost)
 {
   g_socket_use_real = false;
   /* setup */
@@ -121,14 +121,14 @@ Ensure (alivedetection, routethrough_dst_is_not_localhost)
 }
 
 /* If neither dst nor src address are given to routethrough NULL is returned. */
-Ensure (alivedetection, routethrough_no_src_dst_given)
+Ensure (pcap, routethrough_no_src_dst_given)
 {
   gchar *interface = NULL;
   assert_that ((interface = routethrough (NULL, NULL)), is_null);
 }
 
 /* If global_source_addr is present then routethrough writes it into src. */
-Ensure (alivedetection, routethrough_src_globalsource_set)
+Ensure (pcap, routethrough_src_globalsource_set)
 {
   /* setup */
   g_socket_use_real = false;
@@ -156,7 +156,7 @@ Ensure (alivedetection, routethrough_src_globalsource_set)
 }
 
 /* If global_source_addr is not present then routethrough writes it into src. */
-Ensure (alivedetection, routethrough_src_globalsource_not_set)
+Ensure (pcap, routethrough_src_globalsource_not_set)
 {
   g_socket_use_real = false;
 
@@ -181,7 +181,7 @@ Ensure (alivedetection, routethrough_src_globalsource_not_set)
   g_socket_use_real = true;
 }
 
-Ensure (alivedetection, v6_islocalhost)
+Ensure (pcap, v6_islocalhost)
 {
   /* IPv4 */
   struct in_addr addr;
@@ -214,7 +214,7 @@ Ensure (alivedetection, v6_islocalhost)
   assert_that (v6_islocalhost (&addr_6), is_false);
 }
 
-Ensure (alivedetection, islocalhost)
+Ensure (pcap, islocalhost)
 {
   /* IPv4 */
   struct in_addr addr;
@@ -239,16 +239,16 @@ TestSuite *
 openvas_routethrough ()
 {
   TestSuite *suite = create_test_suite ();
-  add_test_with_context (suite, alivedetection, routethrough_dst_is_localhost);
-  add_test_with_context (suite, alivedetection,
+  add_test_with_context (suite, pcap, routethrough_dst_is_localhost);
+  add_test_with_context (suite, pcap,
                          routethrough_dst_is_not_localhost);
-  add_test_with_context (suite, alivedetection, routethrough_no_src_dst_given);
-  add_test_with_context (suite, alivedetection,
+  add_test_with_context (suite, pcap, routethrough_no_src_dst_given);
+  add_test_with_context (suite, pcap,
                          routethrough_src_globalsource_set);
-  add_test_with_context (suite, alivedetection,
+  add_test_with_context (suite, pcap,
                          routethrough_src_globalsource_not_set);
-  add_test_with_context (suite, alivedetection, v6_islocalhost);
-  add_test_with_context (suite, alivedetection, islocalhost);
+  add_test_with_context (suite, pcap, v6_islocalhost);
+  add_test_with_context (suite, pcap, islocalhost);
 
   return suite;
 }


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Original `ipv6addrmask()` has several limitations and bugs. It only had a byte size resolution. E.g. masking with mask=124 yielded an erroneous result. It included some hacky way of clearing an uint32_t which seems to be not supported with modern compilers
anymore which resulted in not clearing anything if the prefix was a multiple of 32 on some compilation configurations.

`v6_is_local_ip()` and `v6_routethrough()` are now using the new function.

**Why**:

Fixing bug, improving code.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Added tests.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
