### PR TITLE
Fix v6_routethrough misplaced technique switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - When routes with same mask are found the route with the better metric is chosen. [#593](https://github.com/greenbone/openvas/pull/593)
 - Fix malformed target. [#625](https://github.com/greenbone/openvas/pull/625)
 - Fix snmp result. Only return the value and do not stop at the first \n. [#627](https://github.com/greenbone/openvas/pull/627)
+- Fix technique switch for getting the appropriate interface to use for IPv6 dst addr. [#636](https://github.com/greenbone/openvas/pull/636)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -907,8 +907,8 @@ v6_routethrough (struct in6_addr *dest, struct in6_addr *source)
                 }
               return myroutes[i].dev->name;
             }
-          technique = connectsockettechnique;
         }
+      technique = connectsockettechnique;
     }
   if (technique == connectsockettechnique)
     {


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

procroutetechnique is the default technique for getting the interface we want to use for some given destination addr. This technique is represented as a static enum. Previously the technique was set to fallback method connectsockettechnique even though an appropriate interface was found because the fallback method was activated after the first route in /proc/net/ipv6_route was checked and not after all routes were checked. Every additional invocation of the function therefore used the fallback method as new default.

**Why**:

<!-- Why are these changes necessary? -->
Fix issue, improve performance.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Add the following code at the beginning of openvas.c/openvas() and add some prints in misc/pcap.c/v6_routethrough() for printing out what method we are using.

```C
  char *interface;
  struct in6_addr dest;
  inet_pton(AF_INET6, <ipv6 addr with matching route in /proc/net/ipv6_route>, &dest);
  interface = v6_routethrough (&dest, NULL);
  g_warning("%s: interface: %s",__func__, interface);
  interface = v6_routethrough (&dest, NULL);
  g_warning("%s: interface: %s",__func__, interface);
  inet_pton(AF_INET6, <ipv6 addr with NO matching route in /proc/net/ipv6_route>, &dest);
  interface = v6_routethrough (&dest, NULL);
  g_warning("%s: interface: %s",__func__, interface);
  exit (0);
```

Result should be something like the following with the PR:

```
>> using procroutetechnique
>> interface: enp0s3
>> using procroutetechnique
>> interface: enp0s3
>> using connectsockettechnique
>> interface: enp0s9
```

And something like the following without the PR:

```
>> using procroutetechnique
>> interface: enp0s3
>> using connectsockettechnique
>> interface: enp0s3
>> using connectsockettechnique
>> interface: enp0s9
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
