### PR TITLE
Use metric and IPv6 dst prefix length when finding best route for ipv6 dst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check if another forked child has already added the same vhost. [#581](https://github.com/greenbone/openvas/pull/581)
 - Send duplicated hosts as dead hosts to ospd, to adjust scan progress calculation. [#586](https://github.com/greenbone/openvas/pull/586)
 - Only send the signal if the pid is a positive value. [#593](https://github.com/greenbone/openvas/pull/593)
-- When routes with same mask are found the route with the better metric is chosen. [#593](https://github.com/greenbone/openvas/pull/593)
+- When routes with same mask are found the route with the better metric is chosen.
+  [#593](https://github.com/greenbone/openvas/pull/593)
+  [#639](https://github.com/greenbone/openvas/pull/639)
 - Fix malformed target. [#625](https://github.com/greenbone/openvas/pull/625)
 - Fix snmp result. Only return the value and do not stop at the first \n. [#627](https://github.com/greenbone/openvas/pull/627)
 - Fix masking of IPv6 addresses. [#635](https://github.com/greenbone/openvas/pull/635)

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -707,6 +707,17 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
     return -1;
 }
 
+/**
+ * @brief Get the IPv6 routes and number of routes.
+ *
+ * This function parses the /proc/net/ipv6_route file into an array of
+ * myroute structs.
+ *
+ * @param[out] myroutes Array of routes.
+ * @param[out] numroutes Number of routes in myroutes.
+ *
+ * @return 0 on success, -1 when no routes are found.
+ */
 int
 getipv6routes (struct myroute *myroutes, int *numroutes)
 {
@@ -761,14 +772,33 @@ getipv6routes (struct myroute *myroutes, int *numroutes)
               endptr = NULL;
               myroutes[*numroutes].mask = strtoul (token, &endptr, 16);
             }
-          cnt = 7;
+
+          /* set metric */
+          cnt = 4;
           while (cnt--)
             {
               token = strtok (NULL, " \t\n");
               if (!token)
                 g_message ("getipv6routes error");
             }
+          endptr = NULL;
+          myroutes[*numroutes].metric = strtoul (token, &endptr, 16);
+          if (!endptr || *endptr)
+            {
+              g_message (
+                "%s: Failed to determine metric from /proc/net/ipv6_route",
+                __func__);
+              continue;
+            }
 
+          /* set interface name */
+          cnt = 3;
+          while (cnt--)
+            {
+              token = strtok (NULL, " \t\n");
+              if (!token)
+                g_message ("getipv6routes error");
+            }
           bzero (iface, sizeof (iface));
           token = strtok (NULL, " \t\n");
           if (token)


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Previously the first matching route for a given destination was taken for getting the interface to use.
Now the metric and the length of the IPv6 "mask" is also taken into account for determining the best matching route.

Already fixed for ipv4 in https://github.com/greenbone/openvas/pull/610

**Why**:

<!-- Why are these changes necessary? -->

Sometimes a less optimal route was chosen which resulted in getting the wrong interface.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Add different routes with something like `sudo ip -6 addr add 2001:db8:0:f104::/64 dev enp0s3` and test via the following code which can be put in the pcap_tests.c file. This code was not committed into the tests because its working is dependent on the local /proc/net/ipv6_route file.

```C
Ensure (pcap, v6_routethrough)
{
  struct in6_addr dest;
  struct in6_addr dst2;
  struct in6_addr src;
  char *interface;
  char addr1[INET6_ADDRSTRLEN];

  // example dst addr. You need to add your own ipv6 here depending on what you want to test.
  const uint8_t one1_in[16] = {0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0xF1, 0x04,
                               0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
  memcpy (dest.s6_addr, one1_in, sizeof one1_in);
  // example dst2 addr.  You need to add your own ipv6 here depending on what you want to test.
  const uint8_t two1_in[16] = {0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0xF1, 0x04,
                               0x10, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01};
  memcpy (dst2.s6_addr, two1_in, sizeof two1_in);

  interface = v6_routethrough (&dest, &src);
  g_warning ("Interface: %s", interface);
  g_warning ("src: %s", inet_ntop (AF_INET6, &src, addr1, sizeof (addr1)));

  interface = v6_routethrough (&dst2, &src);
  g_warning ("Interface: %s", interface);
  g_warning ("src: %s", inet_ntop (AF_INET6, &src, addr1, sizeof (addr1)));

  assert_that (0, is_true); // debug info will be printed. Use correct asserts as needed instead.
}
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
