### PR TITLE
Send the hosts count to the client as -1, because the invalid target list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix snmp result. Only return the value and do not stop at the first \n. [#627](https://github.com/greenbone/openvas/pull/627)
 - Fix masking of IPv6 addresses. [#635](https://github.com/greenbone/openvas/pull/635)
 - Fix technique switch for getting the appropriate interface to use for IPv6 dst addr. [#636](https://github.com/greenbone/openvas/pull/636)
+- Fix host count. Set to -1 when the target string is invalid. [#646](https://github.com/greenbone/openvas/pull/646)
 
 [20.08]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -71,6 +71,10 @@
  * process bar.
  */
 #define PROGRESS_BAR_STYLE 1
+/**
+ * Define value to be sent to the client for invalid target list.
+ **/
+#define INVALID_TARGET_LIST "-1"
 
 #undef G_LOG_DOMAIN
 /**
@@ -1082,9 +1086,12 @@ attack_network (struct scan_globals *globals)
       connect_main_kb (&main_kb);
       message_to_client (main_kb, buffer, NULL, NULL, "ERRMSG");
       g_free (buffer);
+      /* Send the hosts count to the client as -1,
+       * because the invalid target list.*/
+      message_to_client (main_kb, INVALID_TARGET_LIST, NULL, NULL,
+                         "HOSTS_COUNT");
       kb_lnk_reset (main_kb);
       g_warning ("Invalid target list. Scan terminated.");
-      set_scan_status ("finished");
       goto stop;
     }
 


### PR DESCRIPTION
**What**:
Send the hosts count to the client as -1, because the invalid target list

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This allows ospd to finish the scan gracefully, setting the scan to finished
instead of interrupted, but sending the error message as well.

<!-- Why are these changes necessary? -->

**How**:
- Set debug log level in ospd. 
- Start a scan with an invalid target list (only possible via gvm-cli, as gsa wont you to create a invalid target). 
- See in the log that ospd-openvas receives the update of amount of host from openvas set to -1

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
